### PR TITLE
Update documentation to support eq version 0.0.2

### DIFF
--- a/docs/dx-eq.rst
+++ b/docs/dx-eq.rst
@@ -29,12 +29,12 @@ Schema definition
     Will always be "uk.gov.ons.edc.eq:surveyresponse"
   version
     The version number of the schema definition used to generate and parse the
-    schema. Will always be 3 numbers separated by two dots e.g. "10.2.33" with the 
-    intention being MAJOR.MINOR.PATCH no guarantees are given to compatibility 
+    schema. Will always be 3 numbers separated by two dots e.g. "10.2.33" with the
+    intention being MAJOR.MINOR.PATCH no guarantees are given to compatibility
     across version changes.
   origin
     The name or identifier of the data capture / data generator system. Currently,
-    the only option for this is "uk.gov.ons.edc.eq" - however this allows us to 
+    the only option for this is "uk.gov.ons.edc.eq" - however this allows us to
     futureproof for new collection instruments.
   survey_id
     The numerical survey number as used across the ONS.
@@ -56,12 +56,33 @@ Schema definition
       Reporting Unit reference number to which the collected data represents. This
       allows the downstream system to map the responses to individual business/household/person
       in the original sample as created by the survey team.
-  paradata
-    Placeholder block for possible paradata measures.
   data
-    A key, value pairing of responses from a respondent, making use of the box_code / stat_var / q_code as the
-    key to identify the captured respondence from a user.
+    Version 0.0.1
+        A key, value pairing of responses from a respondent, making use of the box_code / stat_var / q_code as the key to identify the captured respondence from a user.
+    Version 0.0.2
+        A sorted array of answers in the order the questionnaire was answered.
 
+        **Dictionary of values**
+
+        - value: The answer given in the questionnaire for the answer.
+        - block_id: The identifier of the page the answer appears on.
+        - answer_id: The identifier of the answer.
+        - group_id: The identifier of the group of block_id/pages.
+        - group_instance: The sub-identifier of a group of block_id/pages if that group repeats.
+        - answer_instance: The sub-identifier of an answer if that answer repeats.
+
+**Version 0.0.2 data example**
+
+.. code-block:: javascript
+
+    [{
+        "value": "Joe Bloggs",
+        "block_id": "household-composition",
+        "answer_id": "household-full-name",
+        "group_id": "multiple-questions-group",
+        "group_instance": 0,
+        "answer_instance": 0
+    }]
 
 
 
@@ -87,7 +108,6 @@ Example Json payload
         "user_id": "789473423",
         "ru_ref": "432423423423"
       },
-      "paradata": {},
       "data": {
         "001": "2016-01-01",
         "002": "2016-03-30"

--- a/docs/dx-eq.rst
+++ b/docs/dx-eq.rst
@@ -59,6 +59,16 @@ Schema definition
   data
     Version 0.0.1
         A key, value pairing of responses from a respondent, making use of the box_code / stat_var / q_code as the key to identify the captured respondence from a user.
+
+        **Version 0.0.1 data example**
+
+        .. code-block:: javascript
+
+            {
+              "001": "2016-01-01",
+              "002": "2016-03-30"
+            }
+
     Version 0.0.2
         A sorted array of answers in the order the questionnaire was answered.
 
@@ -71,18 +81,18 @@ Schema definition
         - group_instance: The sub-identifier of a group of block_id/pages if that group repeats.
         - answer_instance: The sub-identifier of an answer if that answer repeats.
 
-**Version 0.0.2 data example**
+        **Version 0.0.2 data example**
 
-.. code-block:: javascript
+        .. code-block:: javascript
 
-    [{
-        "value": "Joe Bloggs",
-        "block_id": "household-composition",
-        "answer_id": "household-full-name",
-        "group_id": "multiple-questions-group",
-        "group_instance": 0,
-        "answer_instance": 0
-    }]
+            [{
+                "value": "Joe Bloggs",
+                "block_id": "household-composition",
+                "answer_id": "household-full-name",
+                "group_id": "multiple-questions-group",
+                "group_instance": 0,
+                "answer_instance": 0
+            }]
 
 
 


### PR DESCRIPTION
* Removing paradata as this is optional in SDX and is defaulted to an empty json object.
* Defining data structure in version 0.0.2.

I have ran https://github.com/ONSdigital/sdx-validate to validate the new structure and it fails when validating the version `0.0.2` and fails validation of the data