### PR TITLE
Add jti claim to payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,6 @@ target/
 #Ipython Notebook
 .ipynb_checkpoints
 
+# IDE/OS
 .DS_Store
+.idea

--- a/docs/jwt_profile.rst
+++ b/docs/jwt_profile.rst
@@ -1,7 +1,7 @@
 JWT Profile
 -----------
 
-Where a definition uses JWT it SHALL conform to the following profile:
+Where a definition uses JWT it **SHALL** conform to the following profile:
 
 The payload is contained within a JSON Web Tokens (JWT) ~ RFC 7519 signed as
 per JSON Web Signature (JWS) ~ RFC 7515. The signed JWT is used as the payload
@@ -11,9 +11,20 @@ All definitions are as per the RFCs unless otherwise stated.
 
 Note: All times will be UTC.
 
+GUID Definition
+===============
+All references to GUIDs refer to GUID (version 4); 128-bits in length as defined
+in RFC 4122 in their textual representation as defined in section 3
+"Namespace Registration Template" without the "urn:uuid:" prefix e.g.
+"f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
+
+All GUIDs **MUST** be randomly generated such that there is negligible probability
+that the same value will be used twice, even across multiple servers. The same
+GUID value **MUST NOT** appear twice in the same JWT in any claim.
+
 JWS Protected Header
 ====================
-JWS Protected Header SHALL contain the following claims:
+JWS Protected Header **SHALL** contain the following claims:
 
 * 'typ' will be set to 'JWT'
 * 'alg' will be set to 'RS256'
@@ -21,16 +32,18 @@ JWS Protected Header SHALL contain the following claims:
 
 JWT Payload
 ===========
-All JWT payloads SHALL include the follow claims:
-
-    'tx_id'
-        Transaction ID used to trace a transaction through the whole system.
-        This will be a GUID (version 4) and 128-bits in length as defined in RFC 4122 in
-        its textual representation as defined in section 3 "Namespace Registration
-        Template" without the "urn:uuid:" prefix e.g.
-        "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
+All JWT payloads **SHALL** include the follow claims:
+  'tx_id' - Set to a random GUID.
+    - Transaction ID used to trace a transaction through the whole system.
+    - **MUST NOT** be the same as the 'jti' value if present.
 
 
+All JWT payloads **SHOULD** contain the follow claims:
+
+  'jti' - Set to a random GUID. See RFC 7519 definition of the 'jti' claim.
+    - If the 'jti' claim is present it **MUST NOT** be the same value as the
+      'tx_id' in the JWT Payload if present (see GUID Definition).
+    - Note: This claim will become mandatory in future.
 
 The JWT payload can also contain specific other data (claims) defined in the
 definitions within this website.


### PR DESCRIPTION
Adding the 'jti' claim (https://tools.ietf.org/html/rfc7519#section-4.1.7) to the Payload so we can mitigate replay attacks.

Note: tx_id and jti are NOT the same value and MUST be set to different GUIDs.