### PR TITLE
Change completed flag to flushed in SDX payload

### DIFF
--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -36,8 +36,8 @@ Schema Definition
     futureproof for new collection instruments.
   survey_id
     The numerical survey number as used across the ONS.
-  completed
-    Whether the survey was completed or not. This will be `true` if a respondent submitted the survey and `false` if the partially completed survey has been flushed through EQ (some surveys will have their partially completed submissions flushed through at the end of their collection period).
+  flushed
+    Whether the survey was flushed or not. This will be `true` if the partially completed survey has been flushed through EQ (surveys could have their partially completed submissions flushed through at the end of their collection period) and `false` otherwise.
   collection
     exercise_sid
       Collection exercise ID

--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -36,7 +36,7 @@ Schema Definition
     futureproof for new collection instruments.
   survey_id
     The numerical survey number as used across the ONS.
-  flushqed
+  flushed
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   collection
     exercise_sid

--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -36,8 +36,8 @@ Schema Definition
     futureproof for new collection instruments.
   survey_id
     The numerical survey number as used across the ONS.
-  flushed
-    Whether the survey was flushed or not. This will be `true` if the partially completed survey has been flushed through EQ (surveys could have their partially completed submissions flushed through at the end of their collection period) and `false` otherwise.
+  flushqed
+    Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   collection
     exercise_sid
       Collection exercise ID


### PR DESCRIPTION
Renamed the flag `flushed` rather than `completed` to be more explicit. In discussions it was decided that `completed` is not clear as respondents could complete a survey but not submit it. 