### PR TITLE
Change example JSON payload completed not flushed

### DIFF
--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -116,7 +116,7 @@ Example Json payload
       "version" : "0.0.1",
       "origin" : "uk.gov.ons.edc.eq",
       "survey_id": "021",
-      "completed": true,
+      "flushed": false,
       "collection":{
         "exercise_sid": "hfjdskf",
         "instrument_id": "yui789",


### PR DESCRIPTION
The example JSON payload was incorrect, the 'completed' flag should be 'flushed'