### PR TITLE
Added survey_url claim to documentation

### DIFF
--- a/docs/respondent_management_to_electronic_questionnaire.rst
+++ b/docs/respondent_management_to_electronic_questionnaire.rst
@@ -39,6 +39,8 @@ Schema Definition
     A specific date for the questionnaire to display to the respondent.
   form_type
     The particular form_type for a responding unit
+  survey_url
+    An optional URL for a survey JSON to run
   return_by
     A date which represents the return date for a particular collection exercise for a survey. Represented by a ISO_8601 YYYY-MM-DD date.
   roles

--- a/docs/respondent_management_to_electronic_questionnaire.rst
+++ b/docs/respondent_management_to_electronic_questionnaire.rst
@@ -40,7 +40,7 @@ Schema Definition
   form_type
     The particular form_type for a responding unit
   survey_url
-    An optional URL for a survey JSON to run
+    An optional URL for a remote survey JSON. This claim is used to tell Survey Runner to load the schema JSON from a remote location
   return_by
     A date which represents the return date for a particular collection exercise for a survey. Represented by a ISO_8601 YYYY-MM-DD date.
   roles


### PR DESCRIPTION
Added a claim to the documentation for the survey url to be passed across. This claim is used to tell Survey Runner to load the schema JSON from a remote location