### PR TITLE
Add case id to docs

### DIFF
--- a/docs/survey_data_exchange_to_respondent_account_services.rst
+++ b/docs/survey_data_exchange_to_respondent_account_services.rst
@@ -18,3 +18,5 @@ Schema Definition
     The contents of the Collection Instrument base64 encoded
   filename
     The name of the collection instrument file
+  case_id
+    The case UUID


### PR DESCRIPTION
SEFT consumer service requires 'case_id' for creating a receipt via the rm sdx gateway. Which is why ras collection instrument will now pass a 'case_id'.