### PR TITLE
Adding case id and account_service_url

### DIFF
--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -36,6 +36,10 @@ Schema Definition
     futureproof for new collection instruments.
   survey_id
     The numerical survey number as used across the ONS.
+  case_id
+    The case UUID - used to identify a single instance of a survey collection for a respondent
+  account_service_url
+    The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
   flushed
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   collection

--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -37,11 +37,9 @@ Schema Definition
   survey_id
     The numerical survey number as used across the ONS.
   case_id
-    The case UUID - used to identify a single instance of a survey collection for a respondent
+    The case UUID used to identify a single instance of a survey collection for a respondent [optional]
   case_ref
-    The case reference identified by the above UUID (e.g. "1000000000000001")
-  account_service_url
-    The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
+    The case reference identified by the above UUID (e.g. "1000000000000001") [optional]
   flushed
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   collection

--- a/docs/electronic_questionnaire_to_data_exchange.rst
+++ b/docs/electronic_questionnaire_to_data_exchange.rst
@@ -38,6 +38,8 @@ Schema Definition
     The numerical survey number as used across the ONS.
   case_id
     The case UUID - used to identify a single instance of a survey collection for a respondent
+  case_ref
+    The case reference identified by the above UUID (e.g. "1000000000000001")
   account_service_url
     The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
   flushed

--- a/docs/respondent_management_to_electronic_questionnaire.rst
+++ b/docs/respondent_management_to_electronic_questionnaire.rst
@@ -26,11 +26,11 @@ Schema Definition
   eq_id
     The eQ questionnaire instance id.
   case_id
-    The case UUID used to identify a single instance of a survey collection for a respondent
+    The case UUID used to identify a single instance of a survey collection for a respondent [optional]
   case_ref
-    The case reference identified by the above UUID (e.g. "1000000000000001")
+    The case reference identified by the above UUID (e.g. "1000000000000001") [optional]
   account_service_url
-    The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
+    The url of the account service (i.e. rrm or ras) used to launch the survey [optional]
   collection_exercise_sid
     A reference number used to represent the collection exercise inside the ONS
   period_id

--- a/docs/respondent_management_to_electronic_questionnaire.rst
+++ b/docs/respondent_management_to_electronic_questionnaire.rst
@@ -25,6 +25,10 @@ Schema Definition
     The trading as name for a responding unit. Temporary until wider refactor.
   eq_id
     The eQ questionnaire instance id.
+  case_id
+    The case UUID - used to identify a single instance of a survey collection for a respondent
+  account_service_url
+    The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
   collection_exercise_sid
     A reference number used to represent the collection exercise inside the ONS
   period_id

--- a/docs/respondent_management_to_electronic_questionnaire.rst
+++ b/docs/respondent_management_to_electronic_questionnaire.rst
@@ -26,7 +26,9 @@ Schema Definition
   eq_id
     The eQ questionnaire instance id.
   case_id
-    The case UUID - used to identify a single instance of a survey collection for a respondent
+    The case UUID used to identify a single instance of a survey collection for a respondent
+  case_ref
+    The case reference identified by the above UUID (e.g. "1000000000000001")
   account_service_url
     The url of the account service (i.e. rrm or ras) to send the user back to once they've completed the EQ survey
   collection_exercise_sid


### PR DESCRIPTION
Adding case id and account service url to the eq to sdx schema definition. This allows SDX to receipt to RM/RAS once EQ services are migrated to the new system.