### PR TITLE
Adding initial schema and example for EQ submissions

### DIFF
--- a/examples/eq_submission_example.json
+++ b/examples/eq_submission_example.json
@@ -1,208 +1,206 @@
 {
-    "submission": {
-        "tx_id": "1d08aa23-42fa-4825-bfe1-bb9708f59093",
-        "type": "uk.gov.ons.edc.eq:surveyresponse",
-        "version": "0.0.3",
-        "origin": "uk.gov.ons.edc.eq",
-        "survey_id": "census",
-        "flushed": false,
-        "submitted_at": "2019-07-12T16:37:34.826725",
-        "collection": {
-            "exercise_sid": "d133f595-f1de-479c-9da8-2be7a69f2289",
-            "schema_name": "census_household_gb_eng",
-            "period": "201605"
+    "tx_id": "1d08aa23-42fa-4825-bfe1-bb9708f59093",
+    "type": "uk.gov.ons.edc.eq:surveyresponse",
+    "version": "0.0.3",
+    "origin": "uk.gov.ons.edc.eq",
+    "survey_id": "census",
+    "flushed": false,
+    "submitted_at": "2019-07-12T16:37:34.826725",
+    "collection": {
+        "exercise_sid": "d133f595-f1de-479c-9da8-2be7a69f2289",
+        "schema_name": "census_household_gb_eng",
+        "period": "201605"
+    },
+    "metadata": {
+        "user_id": "UNKNOWN",
+        "ru_ref": "58682679334u"
+    },
+    "response_id": "7863675602300568",
+    "questionnaire_id": "8258531582413918",
+    "started_at": "2019-07-12T16:35:31.068047",
+    "case_id": "982445c0-7afd-49f5-a74e-5bb2a05faf1a",
+    "data": [
+        {
+            "answer_id": "accommodation-type-answer",
+            "value": "A private or family household"
         },
-        "metadata": {
-            "user_id": "UNKNOWN",
-            "ru_ref": "58682679334u"
+        {
+            "answer_id": "proxy-answer",
+            "value": "No"
         },
-        "response_id": "7863675602300568",
-        "questionnaire_id": "8258531582413918",
-        "started_at": "2019-07-12T16:35:31.068047",
-        "case_id": "982445c0-7afd-49f5-a74e-5bb2a05faf1a",
-        "data": [
-            {
-                "answer_id": "accommodation-type-answer",
-                "value": "A private or family household"
-            },
-            {
-                "answer_id": "proxy-answer",
-                "value": "No"
-            },
-            {
-                "answer_id": "first-name",
-                "value": "John"
-            },
-            {
-                "answer_id": "middle-names",
-                "value": "Bob"
-            },
-            {
-                "answer_id": "last-name",
-                "value": "Smith"
-            },
-            {
-                "answer_id": "date-of-birth-answer",
-                "value": "1975-01-01"
-            },
-            {
-                "answer_id": "confirm-date-of-birth-answer",
-                "value": "Yes"
-            },
-            {
-                "answer_id": "sex-answer",
-                "value": "Male"
-            },
-            {
-                "answer_id": "marriage-type-answer",
-                "value": "Surviving partner from a registered civil partnership"
-            },
-            {
-                "answer_id": "previous-partnership-status-answer",
-                "value": "Someone of the opposite sex"
-            },
-            {
-                "answer_id": "another-address-answer",
-                "value": "No"
-            },
-            {
-                "answer_id": "in-education-answer",
-                "value": "No"
-            },
-            {
-                "answer_id": "country-of-birth-answer",
-                "value": "Wales"
-            },
-            {
-                "answer_id": "language-answer",
-                "value": "English"
-            },
-            {
-                "answer_id": "national-identity-answer",
-                "value": [
-                    "English",
-                    "Welsh"
-                ]
-            },
-            {
-                "answer_id": "ethnic-group-answer",
-                "value": "Mixed or Multiple ethnic groups"
-            },
-            {
-                "answer_id": "mixed-ethnic-group-answer",
-                "value": "White and Black African"
-            },
-            {
-                "answer_id": "religion-answer",
-                "value": [
-                    "Christian",
-                    "Buddhist"
-                ]
-            },
-            {
-                "answer_id": "past-usual-address-household-answer",
-                "value": "household-address"
-            },
-            {
-                "answer_id": "passports-answer",
-                "value": [
-                    "United Kingdom"
-                ]
-            },
-            {
-                "answer_id": "health-answer",
-                "value": "Very good"
-            },
-            {
-                "answer_id": "disability-answer",
-                "value": "No"
-            },
-            {
-                "answer_id": "carer-answer",
-                "value": "Yes, 9 hours a week or less"
-            },
-            {
-                "answer_id": "birth-gender-answer",
-                "value": [
-                    "Yes"
-                ]
-            },
-            {
-                "answer_id": "apprenticeship-answer",
-                "value": "Yes"
-            },
-            {
-                "answer_id": "degree-answer",
-                "value": "Yes"
-            },
-            {
-                "answer_id": "nvq-level-answer",
-                "value": [
-                    "NVQ level 2 or equivalent",
-                    "NVQ level 1 or equivalent"
-                ]
-            },
-            {
-                "answer_id": "a-level-answer",
-                "value": [
-                    "2 or more A levels",
-                    "1 A level"
-                ]
-            },
-            {
-                "answer_id": "gcse-answer",
-                "value": [
-                    "5 or more GCSEs"
-                ]
-            },
-            {
-                "answer_id": "armed-forces-answer",
-                "value": [
-                    "No"
-                ]
-            },
-            {
-                "answer_id": "employment-status-answer",
-                "value": [
-                    "Working as an employee"
-                ]
-            },
-            {
-                "answer_id": "main-job-type-answer",
-                "value": "Employee"
-            },
-            {
-                "answer_id": "business-name-answer",
-                "value": "Bob's Business"
-            },
-            {
-                "answer_id": "job-title-answer",
-                "value": "Bobber"
-            },
-            {
-                "answer_id": "job-description-answer",
-                "value": "Bobbing Stuff"
-            },
-            {
-                "answer_id": "employers-business-answer",
-                "value": "Bobery"
-            },
-            {
-                "answer_id": "supervise-answer",
-                "value": "No"
-            },
-            {
-                "answer_id": "hours-worked-answer",
-                "value": "31 to 48 hours"
-            },
-            {
-                "answer_id": "work-travel-answer",
-                "value": "Work mainly at or from home"
-            },
-            {
-                "answer_id": "employer-type-of-address-answer",
-                "value": "At or from home"
-            }
-        ]
-    }
+        {
+            "answer_id": "first-name",
+            "value": "John"
+        },
+        {
+            "answer_id": "middle-names",
+            "value": "Bob"
+        },
+        {
+            "answer_id": "last-name",
+            "value": "Smith"
+        },
+        {
+            "answer_id": "date-of-birth-answer",
+            "value": "1975-01-01"
+        },
+        {
+            "answer_id": "confirm-date-of-birth-answer",
+            "value": "Yes"
+        },
+        {
+            "answer_id": "sex-answer",
+            "value": "Male"
+        },
+        {
+            "answer_id": "marriage-type-answer",
+            "value": "Surviving partner from a registered civil partnership"
+        },
+        {
+            "answer_id": "previous-partnership-status-answer",
+            "value": "Someone of the opposite sex"
+        },
+        {
+            "answer_id": "another-address-answer",
+            "value": "No"
+        },
+        {
+            "answer_id": "in-education-answer",
+            "value": "No"
+        },
+        {
+            "answer_id": "country-of-birth-answer",
+            "value": "Wales"
+        },
+        {
+            "answer_id": "language-answer",
+            "value": "English"
+        },
+        {
+            "answer_id": "national-identity-answer",
+            "value": [
+                "English",
+                "Welsh"
+            ]
+        },
+        {
+            "answer_id": "ethnic-group-answer",
+            "value": "Mixed or Multiple ethnic groups"
+        },
+        {
+            "answer_id": "mixed-ethnic-group-answer",
+            "value": "White and Black African"
+        },
+        {
+            "answer_id": "religion-answer",
+            "value": [
+                "Christian",
+                "Buddhist"
+            ]
+        },
+        {
+            "answer_id": "past-usual-address-household-answer",
+            "value": "household-address"
+        },
+        {
+            "answer_id": "passports-answer",
+            "value": [
+                "United Kingdom"
+            ]
+        },
+        {
+            "answer_id": "health-answer",
+            "value": "Very good"
+        },
+        {
+            "answer_id": "disability-answer",
+            "value": "No"
+        },
+        {
+            "answer_id": "carer-answer",
+            "value": "Yes, 9 hours a week or less"
+        },
+        {
+            "answer_id": "birth-gender-answer",
+            "value": [
+                "Yes"
+            ]
+        },
+        {
+            "answer_id": "apprenticeship-answer",
+            "value": "Yes"
+        },
+        {
+            "answer_id": "degree-answer",
+            "value": "Yes"
+        },
+        {
+            "answer_id": "nvq-level-answer",
+            "value": [
+                "NVQ level 2 or equivalent",
+                "NVQ level 1 or equivalent"
+            ]
+        },
+        {
+            "answer_id": "a-level-answer",
+            "value": [
+                "2 or more A levels",
+                "1 A level"
+            ]
+        },
+        {
+            "answer_id": "gcse-answer",
+            "value": [
+                "5 or more GCSEs"
+            ]
+        },
+        {
+            "answer_id": "armed-forces-answer",
+            "value": [
+                "No"
+            ]
+        },
+        {
+            "answer_id": "employment-status-answer",
+            "value": [
+                "Working as an employee"
+            ]
+        },
+        {
+            "answer_id": "main-job-type-answer",
+            "value": "Employee"
+        },
+        {
+            "answer_id": "business-name-answer",
+            "value": "Bob's Business"
+        },
+        {
+            "answer_id": "job-title-answer",
+            "value": "Bobber"
+        },
+        {
+            "answer_id": "job-description-answer",
+            "value": "Bobbing Stuff"
+        },
+        {
+            "answer_id": "employers-business-answer",
+            "value": "Bobery"
+        },
+        {
+            "answer_id": "supervise-answer",
+            "value": "No"
+        },
+        {
+            "answer_id": "hours-worked-answer",
+            "value": "31 to 48 hours"
+        },
+        {
+            "answer_id": "work-travel-answer",
+            "value": "Work mainly at or from home"
+        },
+        {
+            "answer_id": "employer-type-of-address-answer",
+            "value": "At or from home"
+        }
+    ]
 }

--- a/examples/eq_submission_example.json
+++ b/examples/eq_submission_example.json
@@ -1,0 +1,208 @@
+{
+    "submission": {
+        "tx_id": "1d08aa23-42fa-4825-bfe1-bb9708f59093",
+        "type": "uk.gov.ons.edc.eq:surveyresponse",
+        "version": "0.0.3",
+        "origin": "uk.gov.ons.edc.eq",
+        "survey_id": "census",
+        "flushed": false,
+        "submitted_at": "2019-07-12T16:37:34.826725",
+        "collection": {
+            "exercise_sid": "d133f595-f1de-479c-9da8-2be7a69f2289",
+            "schema_name": "census_household_gb_eng",
+            "period": "201605"
+        },
+        "metadata": {
+            "user_id": "UNKNOWN",
+            "ru_ref": "58682679334u"
+        },
+        "response_id": "7863675602300568",
+        "questionnaire_id": "8258531582413918",
+        "started_at": "2019-07-12T16:35:31.068047",
+        "case_id": "982445c0-7afd-49f5-a74e-5bb2a05faf1a",
+        "data": [
+            {
+                "answer_id": "accommodation-type-answer",
+                "value": "A private or family household"
+            },
+            {
+                "answer_id": "proxy-answer",
+                "value": "No"
+            },
+            {
+                "answer_id": "first-name",
+                "value": "John"
+            },
+            {
+                "answer_id": "middle-names",
+                "value": "Bob"
+            },
+            {
+                "answer_id": "last-name",
+                "value": "Smith"
+            },
+            {
+                "answer_id": "date-of-birth-answer",
+                "value": "1975-01-01"
+            },
+            {
+                "answer_id": "confirm-date-of-birth-answer",
+                "value": "Yes"
+            },
+            {
+                "answer_id": "sex-answer",
+                "value": "Male"
+            },
+            {
+                "answer_id": "marriage-type-answer",
+                "value": "Surviving partner from a registered civil partnership"
+            },
+            {
+                "answer_id": "previous-partnership-status-answer",
+                "value": "Someone of the opposite sex"
+            },
+            {
+                "answer_id": "another-address-answer",
+                "value": "No"
+            },
+            {
+                "answer_id": "in-education-answer",
+                "value": "No"
+            },
+            {
+                "answer_id": "country-of-birth-answer",
+                "value": "Wales"
+            },
+            {
+                "answer_id": "language-answer",
+                "value": "English"
+            },
+            {
+                "answer_id": "national-identity-answer",
+                "value": [
+                    "English",
+                    "Welsh"
+                ]
+            },
+            {
+                "answer_id": "ethnic-group-answer",
+                "value": "Mixed or Multiple ethnic groups"
+            },
+            {
+                "answer_id": "mixed-ethnic-group-answer",
+                "value": "White and Black African"
+            },
+            {
+                "answer_id": "religion-answer",
+                "value": [
+                    "Christian",
+                    "Buddhist"
+                ]
+            },
+            {
+                "answer_id": "past-usual-address-household-answer",
+                "value": "household-address"
+            },
+            {
+                "answer_id": "passports-answer",
+                "value": [
+                    "United Kingdom"
+                ]
+            },
+            {
+                "answer_id": "health-answer",
+                "value": "Very good"
+            },
+            {
+                "answer_id": "disability-answer",
+                "value": "No"
+            },
+            {
+                "answer_id": "carer-answer",
+                "value": "Yes, 9 hours a week or less"
+            },
+            {
+                "answer_id": "birth-gender-answer",
+                "value": [
+                    "Yes"
+                ]
+            },
+            {
+                "answer_id": "apprenticeship-answer",
+                "value": "Yes"
+            },
+            {
+                "answer_id": "degree-answer",
+                "value": "Yes"
+            },
+            {
+                "answer_id": "nvq-level-answer",
+                "value": [
+                    "NVQ level 2 or equivalent",
+                    "NVQ level 1 or equivalent"
+                ]
+            },
+            {
+                "answer_id": "a-level-answer",
+                "value": [
+                    "2 or more A levels",
+                    "1 A level"
+                ]
+            },
+            {
+                "answer_id": "gcse-answer",
+                "value": [
+                    "5 or more GCSEs"
+                ]
+            },
+            {
+                "answer_id": "armed-forces-answer",
+                "value": [
+                    "No"
+                ]
+            },
+            {
+                "answer_id": "employment-status-answer",
+                "value": [
+                    "Working as an employee"
+                ]
+            },
+            {
+                "answer_id": "main-job-type-answer",
+                "value": "Employee"
+            },
+            {
+                "answer_id": "business-name-answer",
+                "value": "Bob's Business"
+            },
+            {
+                "answer_id": "job-title-answer",
+                "value": "Bobber"
+            },
+            {
+                "answer_id": "job-description-answer",
+                "value": "Bobbing Stuff"
+            },
+            {
+                "answer_id": "employers-business-answer",
+                "value": "Bobery"
+            },
+            {
+                "answer_id": "supervise-answer",
+                "value": "No"
+            },
+            {
+                "answer_id": "hours-worked-answer",
+                "value": "31 to 48 hours"
+            },
+            {
+                "answer_id": "work-travel-answer",
+                "value": "Work mainly at or from home"
+            },
+            {
+                "answer_id": "employer-type-of-address-answer",
+                "value": "At or from home"
+            }
+        ]
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ imagesize==0.7.1
 pytz==2016.10
 recommonmark==0.4.0
 requests==2.13.0
-six==1.10.0
+six==1.12.0
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.1.9
+jsonschema==3.0.1

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -5,280 +5,269 @@
   "type": "object",
   "title": "ONS EQ Submission Schema",
   "required": [
-    "submission"
+    "tx_id",
+    "type",
+    "version",
+    "origin",
+    "survey_id",
+    "flushed",
+    "submitted_at",
+    "collection",
+    "metadata",
+    "response_id",
+    "questionnaire_id",
+    "started_at",
+    "data"
   ],
   "properties": {
-    "submission": {
-      "$id": "#/properties/submission",
+    "tx_id": {
+      "$id": "#/properties/tx_id",
+      "type": "string",
+      "title": "Transaction ID",
+      "description": "Used to trace a transaction through the whole system",
+      "default": "",
+      "examples": [
+        "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+      ],
+      "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+    },
+    "type": {
+      "$id": "#/properties/type",
+      "type": "string",
+      "title": "Type",
+      "description": "The unique type identifier of this JSON file. Can be \"uk.gov.ons.edc.eq:surveyresponse\" or \"uk.gov.ons.edc.eq:feedback\"",
+      "default": "",
+      "examples": [
+        "uk.gov.ons.edc.eq:surveyresponse"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "version": {
+      "$id": "#/properties/version",
+      "type": "string",
+      "title": "Version",
+      "description": "The version number of the schema definition used to generate and parse the schema. Will always be 3 numbers separated by two dots e.g. \"10.2.33\"",
+      "default": "",
+      "examples": [
+        "0.0.3"
+      ],
+      "pattern": "^0.0.3$"
+    },
+    "origin": {
+      "$id": "#/properties/origin",
+      "type": "string",
+      "title": "Origin",
+      "description": "The origin of the submission",
+      "default": "",
+      "examples": [
+        "uk.gov.ons.edc.eq"
+      ],
+      "pattern": "^uk.gov.ons.edc.eq$"
+    },
+    "survey_id": {
+      "$id": "#/properties/survey_id",
+      "type": "string",
+      "title": "Survey_id",
+      "default": "",
+      "examples": [
+        "census"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "flushed": {
+      "$id": "#/properties/flushed",
+      "type": "boolean",
+      "title": "Flushed",
+      "description": "Whether the survey was flushed or not. This will be true if the survey has been flushed through EQ",
+      "default": false,
+      "examples": [
+        false,
+        true
+      ]
+    },
+    "submitted_at": {
+      "$id": "#/properties/submitted_at",
+      "type": "string",
+      "title": "submitted_at",
+      "description": "The datetime of submission by the respondent.",
+      "default": "",
+      "examples": [
+        "2019-07-12T11:44:13.255527"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "collection": {
+      "$id": "#/properties/collection",
       "type": "object",
-      "title": "The Submission Schema",
+      "title": "The Collection Schema",
       "required": [
-        "tx_id",
-        "type",
-        "version",
-        "origin",
-        "survey_id",
-        "flushed",
-        "submitted_at",
-        "collection",
-        "metadata",
-        "response_id",
-        "questionnaire_id",
-        "started_at",
-        "case_id",
-        "data"
+        "exercise_sid",
+        "schema_name",
+        "period"
       ],
       "properties": {
-        "tx_id": {
-          "$id": "#/properties/submission/properties/tx_id",
+        "exercise_sid": {
+          "$id": "#/properties/collection/properties/exercise_sid",
           "type": "string",
-          "title": "Transaction ID",
-          "description": "Used to trace a transaction through the whole system",
+          "title": "Collection exercise ID",
           "default": "",
           "examples": [
-            "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+            "fe1f6c57-2fde-4657-b395-b2c3fa4c21a0"
           ],
           "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
         },
-        "type": {
-          "$id": "#/properties/submission/properties/type",
+        "schema_name": {
+          "$id": "#/properties/collection/properties/schema_name",
           "type": "string",
-          "title": "Type",
-          "description": "The unique type identifier of this JSON file. Can be \"uk.gov.ons.edc.eq:surveyresponse\" or \"uk.gov.ons.edc.eq:feedback\"",
+          "title": "Schema Name",
           "default": "",
           "examples": [
-            "uk.gov.ons.edc.eq:surveyresponse"
+            "census_household_gb_eng",
+            "census_household_gb_nir",
+            "census_individual_gb_wls"
           ],
           "pattern": "^(.*)$"
         },
-        "version": {
-          "$id": "#/properties/submission/properties/version",
+        "period": {
+          "$id": "#/properties/collection/properties/period",
           "type": "string",
-          "title": "Version",
-          "description": "The version number of the schema definition used to generate and parse the schema. Will always be 3 numbers separated by two dots e.g. \"10.2.33\"",
+          "title": "Period",
           "default": "",
           "examples": [
-            "0.0.3"
+            "201605"
           ],
-          "pattern": "^0.0.3$"
-        },
-        "origin": {
-          "$id": "#/properties/submission/properties/origin",
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "metadata": {
+      "$id": "#/properties/metadata",
+      "type": "object",
+      "title": "The Metadata Schema",
+      "required": [
+        "user_id",
+        "ru_ref"
+      ],
+      "properties": {
+        "user_id": {
+          "$id": "#/properties/metadata/properties/user_id",
           "type": "string",
-          "title": "Origin",
-          "description": "The origin of the submission",
+          "title": "User ID",
           "default": "",
           "examples": [
-            "uk.gov.ons.edc.eq"
-          ],
-          "pattern": "^uk.gov.ons.edc.eq$"
-        },
-        "survey_id": {
-          "$id": "#/properties/submission/properties/survey_id",
-          "type": "string",
-          "title": "Survey_id",
-          "default": "",
-          "examples": [
-            "census"
+            "UNKNOWN"
           ],
           "pattern": "^(.*)$"
         },
-        "flushed": {
-          "$id": "#/properties/submission/properties/flushed",
-          "type": "boolean",
-          "title": "Flushed",
-          "description": "Whether the survey was flushed or not. This will be true if the survey has been flushed through EQ",
-          "default": false,
-          "examples": [
-            false,
-            true
-          ]
-        },
-        "submitted_at": {
-          "$id": "#/properties/submission/properties/submitted_at",
+        "ru_ref": {
+          "$id": "#/properties/metadata/properties/ru_ref",
           "type": "string",
-          "title": "submitted_at",
-          "description": "The datetime of submission by the respondent.",
+          "title": "Reporting Unit",
           "default": "",
           "examples": [
-            "2019-07-12T11:44:13.255527"
+            "33581872181D"
           ],
           "pattern": "^(.*)$"
-        },
-        "collection": {
-          "$id": "#/properties/submission/properties/collection",
-          "type": "object",
-          "title": "The Collection Schema",
-          "required": [
-            "exercise_sid",
-            "schema_name",
-            "period"
-          ],
-          "properties": {
-            "exercise_sid": {
-              "$id": "#/properties/submission/properties/collection/properties/exercise_sid",
-              "type": "string",
-              "title": "Collection exercise ID",
-              "default": "",
-              "examples": [
-                "fe1f6c57-2fde-4657-b395-b2c3fa4c21a0"
-              ],
-              "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
-            },
-            "schema_name": {
-              "$id": "#/properties/submission/properties/collection/properties/schema_name",
-              "type": "string",
-              "title": "Schema Name",
-              "default": "",
-              "examples": [
-                "census_household_gb_eng",
-                "census_household_gb_nir",
-                "census_individual_gb_wls"
-              ],
-              "pattern": "^(.*)$"
-            },
-            "period": {
-              "$id": "#/properties/submission/properties/collection/properties/period",
-              "type": "string",
-              "title": "Period",
-              "default": "",
-              "examples": [
-                "201605"
-              ],
-              "pattern": "^(.*)$"
-            }
-          }
-        },
-        "metadata": {
-          "$id": "#/properties/submission/properties/metadata",
-          "type": "object",
-          "title": "The Metadata Schema",
-          "required": [
-            "user_id",
-            "ru_ref"
-          ],
-          "properties": {
-            "user_id": {
-              "$id": "#/properties/submission/properties/metadata/properties/user_id",
-              "type": "string",
-              "title": "User ID",
-              "default": "",
-              "examples": [
-                "UNKNOWN"
-              ],
-              "pattern": "^(.*)$"
-            },
-            "ru_ref": {
-              "$id": "#/properties/submission/properties/metadata/properties/ru_ref",
-              "type": "string",
-              "title": "Reporting Unit",
-              "default": "",
-              "examples": [
-                "33581872181D"
-              ],
-              "pattern": "^(.*)$"
-            }
-          }
-        },
-        "response_id": {
-          "$id": "#/properties/submission/properties/response_id",
-          "type": "string",
-          "title": "Response ID",
-          "default": "",
-          "examples": [
-            "7579781590275801"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "questionnaire_id": {
-          "$id": "#/properties/submission/properties/questionnaire_id",
-          "type": "string",
-          "title": "Questionnaire ID",
-          "default": "",
-          "examples": [
-            "4782576236675773"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "started_at": {
-          "$id": "#/properties/submission/properties/started_at",
-          "type": "string",
-          "title": "Started At",
-          "description": "The datetime of the first answer saved in a survey",
-          "default": "",
-          "examples": [
-            "2019-07-12T11:41:51.979942"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "case_id": {
-          "$id": "#/properties/submission/properties/case_id",
-          "type": "string",
-          "title": "Case ID",
-          "default": "",
-          "examples": [
-            "42d78898-7e7a-40b9-9500-757bb546e358"
-          ],
-          "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
-        },
-        "data": {
-          "$id": "#/properties/submission/properties/data",
-          "type": "array",
-          "title": "Submitted Data",
-          "items": {
-            "$id": "#/properties/submission/properties/data/items",
-            "type": "object",
-            "title": "The answers submitted",
-            "required": [
-              "answer_id",
-              "value"
+        }
+      }
+    },
+    "response_id": {
+      "$id": "#/properties/response_id",
+      "type": "string",
+      "title": "Response ID",
+      "default": "",
+      "examples": [
+        "7579781590275801"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "questionnaire_id": {
+      "$id": "#/properties/questionnaire_id",
+      "type": "string",
+      "title": "Questionnaire ID",
+      "default": "",
+      "examples": [
+        "4782576236675773"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "started_at": {
+      "$id": "#/properties/started_at",
+      "type": "string",
+      "title": "Started At",
+      "description": "The datetime of the first answer saved in a survey",
+      "default": "",
+      "examples": [
+        "2019-07-12T11:41:51.979942"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "case_id": {
+      "$id": "#/properties/case_id",
+      "type": "string",
+      "title": "Case ID",
+      "default": "",
+      "examples": [
+        "42d78898-7e7a-40b9-9500-757bb546e358"
+      ],
+      "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+    },
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "Submitted Data",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "title": "The answers submitted",
+        "required": [
+          "answer_id",
+          "value"
+        ],
+        "properties": {
+          "answer_id": {
+            "$id": "#/properties/data/items/properties/answer_id",
+            "type": "string",
+            "title": "Answer ID",
+            "default": "",
+            "examples": [
+              "accommodation-type-answer",
+              "first-name",
+              "ethnic-group-answer"
             ],
-            "properties": {
-              "answer_id": {
-                "$id": "#/properties/submission/properties/data/items/properties/answer_id",
-                "type": "string",
-                "title": "Answer ID",
-                "default": "",
-                "examples": [
-                  "accommodation-type-answer",
-                  "first-name",
-                  "ethnic-group-answer"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "value": {
-                "$id": "#/properties/submission/properties/data/items/properties/value",
-                "type": ["string", "array"],
-                "title": "The response value",
-                "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
-                "pattern": "^(.*)$",
-                "items": {
-                  "$id": "#/properties/submission/properties/data/items/properties/value/items",
-                  "type": "string",
-                  "title": "answer value items",
-                  "default": "",
-                  "examples": [
-                    "Christian",
-                    "Buddhist",
-                    "Yes",
-                    "No"
-                  ],
-                  "pattern": "^(.*)$"
-                }
-              },
-              "list_item_id": {
-                "$id": "#/properties/submission/properties/data/items/properties/list_item_id",
-                "type": "string",
-                "title": "List Item ID",
-                "description": "Related items will have the same ID e.g. first name and last name for the same person",
-                "default": "",
-                "examples": [
-                  "LvxBCq",
-                  "Hjkues"                  
-                ],
-                "pattern": "^(.*)$"
-              }
+            "pattern": "^(.*)$"
+          },
+          "value": {
+            "$id": "#/properties/data/items/properties/value",
+            "type": ["string", "array"],
+            "title": "The response value",
+            "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
+            "pattern": "^(.*)$",
+            "items": {
+              "$id": "#/properties/data/items/properties/value/items",
+              "type": "string",
+              "title": "answer value items",
+              "default": "",
+              "examples": [
+                "Christian",
+                "Buddhist",
+                "Yes",
+                "No"
+              ],
+              "pattern": "^(.*)$"
             }
+          },
+          "list_item_id": {
+            "$id": "#/properties/data/items/properties/list_item_id",
+            "type": "string",
+            "title": "List Item ID",
+            "description": "Related items will have the same ID e.g. first name and last name for the same person",
+            "default": "",
+            "examples": [
+              "LvxBCq",
+              "Hjkues"                  
+            ],
+            "pattern": "^(.*)$"
           }
         }
       }

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -1,0 +1,287 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://edc.ons.gov.uk/schemas/eq_submission.json",
+  "type": "object",
+  "title": "ONS EQ Submission Schema",
+  "required": [
+    "submission"
+  ],
+  "properties": {
+    "submission": {
+      "$id": "#/properties/submission",
+      "type": "object",
+      "title": "The Submission Schema",
+      "required": [
+        "tx_id",
+        "type",
+        "version",
+        "origin",
+        "survey_id",
+        "flushed",
+        "submitted_at",
+        "collection",
+        "metadata",
+        "response_id",
+        "questionnaire_id",
+        "started_at",
+        "case_id",
+        "data"
+      ],
+      "properties": {
+        "tx_id": {
+          "$id": "#/properties/submission/properties/tx_id",
+          "type": "string",
+          "title": "Transaction ID",
+          "description": "Used to trace a transaction through the whole system",
+          "default": "",
+          "examples": [
+            "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+          ],
+          "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+        },
+        "type": {
+          "$id": "#/properties/submission/properties/type",
+          "type": "string",
+          "title": "Type",
+          "description": "The unique type identifier of this JSON file. Can be \"uk.gov.ons.edc.eq:surveyresponse\" or \"uk.gov.ons.edc.eq:feedback\"",
+          "default": "",
+          "examples": [
+            "uk.gov.ons.edc.eq:surveyresponse"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "version": {
+          "$id": "#/properties/submission/properties/version",
+          "type": "string",
+          "title": "Version",
+          "description": "The version number of the schema definition used to generate and parse the schema. Will always be 3 numbers separated by two dots e.g. \"10.2.33\"",
+          "default": "",
+          "examples": [
+            "0.0.3"
+          ],
+          "pattern": "^0.0.3$"
+        },
+        "origin": {
+          "$id": "#/properties/submission/properties/origin",
+          "type": "string",
+          "title": "Origin",
+          "description": "The origin of the submission",
+          "default": "",
+          "examples": [
+            "uk.gov.ons.edc.eq"
+          ],
+          "pattern": "^uk.gov.ons.edc.eq$"
+        },
+        "survey_id": {
+          "$id": "#/properties/submission/properties/survey_id",
+          "type": "string",
+          "title": "Survey_id",
+          "default": "",
+          "examples": [
+            "census"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "flushed": {
+          "$id": "#/properties/submission/properties/flushed",
+          "type": "boolean",
+          "title": "Flushed",
+          "description": "Whether the survey was flushed or not. This will be true if the survey has been flushed through EQ",
+          "default": false,
+          "examples": [
+            false,
+            true
+          ]
+        },
+        "submitted_at": {
+          "$id": "#/properties/submission/properties/submitted_at",
+          "type": "string",
+          "title": "submitted_at",
+          "description": "The datetime of submission by the respondent.",
+          "default": "",
+          "examples": [
+            "2019-07-12T11:44:13.255527"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "collection": {
+          "$id": "#/properties/submission/properties/collection",
+          "type": "object",
+          "title": "The Collection Schema",
+          "required": [
+            "exercise_sid",
+            "schema_name",
+            "period"
+          ],
+          "properties": {
+            "exercise_sid": {
+              "$id": "#/properties/submission/properties/collection/properties/exercise_sid",
+              "type": "string",
+              "title": "Collection exercise ID",
+              "default": "",
+              "examples": [
+                "fe1f6c57-2fde-4657-b395-b2c3fa4c21a0"
+              ],
+              "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+            },
+            "schema_name": {
+              "$id": "#/properties/submission/properties/collection/properties/schema_name",
+              "type": "string",
+              "title": "Schema Name",
+              "default": "",
+              "examples": [
+                "census_household_gb_eng",
+                "census_household_gb_nir",
+                "census_individual_gb_wls"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "period": {
+              "$id": "#/properties/submission/properties/collection/properties/period",
+              "type": "string",
+              "title": "Period",
+              "default": "",
+              "examples": [
+                "201605"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "metadata": {
+          "$id": "#/properties/submission/properties/metadata",
+          "type": "object",
+          "title": "The Metadata Schema",
+          "required": [
+            "user_id",
+            "ru_ref"
+          ],
+          "properties": {
+            "user_id": {
+              "$id": "#/properties/submission/properties/metadata/properties/user_id",
+              "type": "string",
+              "title": "User ID",
+              "default": "",
+              "examples": [
+                "UNKNOWN"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "ru_ref": {
+              "$id": "#/properties/submission/properties/metadata/properties/ru_ref",
+              "type": "string",
+              "title": "Reporting Unit",
+              "default": "",
+              "examples": [
+                "33581872181D"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "response_id": {
+          "$id": "#/properties/submission/properties/response_id",
+          "type": "string",
+          "title": "Response ID",
+          "default": "",
+          "examples": [
+            "7579781590275801"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "questionnaire_id": {
+          "$id": "#/properties/submission/properties/questionnaire_id",
+          "type": "string",
+          "title": "Questionnaire ID",
+          "default": "",
+          "examples": [
+            "4782576236675773"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "started_at": {
+          "$id": "#/properties/submission/properties/started_at",
+          "type": "string",
+          "title": "Started At",
+          "description": "The datetime of the first answer saved in a survey",
+          "default": "",
+          "examples": [
+            "2019-07-12T11:41:51.979942"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "case_id": {
+          "$id": "#/properties/submission/properties/case_id",
+          "type": "string",
+          "title": "Case ID",
+          "default": "",
+          "examples": [
+            "42d78898-7e7a-40b9-9500-757bb546e358"
+          ],
+          "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+        },
+        "data": {
+          "$id": "#/properties/submission/properties/data",
+          "type": "array",
+          "title": "Submitted Data",
+          "items": {
+            "$id": "#/properties/submission/properties/data/items",
+            "type": "object",
+            "title": "The answers submitted",
+            "required": [
+              "answer_id",
+              "value"
+            ],
+            "properties": {
+              "answer_id": {
+                "$id": "#/properties/submission/properties/data/items/properties/answer_id",
+                "type": "string",
+                "title": "Answer ID",
+                "default": "",
+                "examples": [
+                  "accommodation-type-answer",
+                  "first-name",
+                  "ethnic-group-answer"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "value": {
+                "$id": "#/properties/submission/properties/data/items/properties/value",
+                "type": ["string", "array"],
+                "title": "The response value",
+                "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
+                "pattern": "^(.*)$",
+                "items": {
+                  "$id": "#/properties/submission/properties/data/items/properties/value/items",
+                  "type": "string",
+                  "title": "answer value items",
+                  "default": "",
+                  "examples": [
+                    "Christian",
+                    "Buddhist",
+                    "Yes",
+                    "No"
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              },
+              "list_item_id": {
+                "$id": "#/properties/submission/properties/data/items/properties/list_item_id",
+                "type": "string",
+                "title": "List Item ID",
+                "description": "Related items will have the same ID e.g. first name and last name for the same person",
+                "default": "",
+                "examples": [
+                  "LvxBCq",
+                  "Hjkues"                  
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/json_validator.py
+++ b/schemas/json_validator.py
@@ -1,0 +1,35 @@
+import json
+import logging
+
+from argparse import ArgumentParser
+from jsonschema import SchemaError, ValidationError, validate
+
+
+def validate_document_with_schema(document, schema):
+    try:
+        validate(document, schema)
+
+    except ValidationError as e:
+        logging.error(
+            'Schema Validation Error! [{}] does not validate against schema. Error [{}]'.format(
+                document, e
+            )
+        )
+
+    except SchemaError as e:
+        logging.error(
+            'JSON Parse Error! Could not parse [{}]. Error [{}]'.format(
+                document, e)
+        )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Validate a JSON document against a JSON schema see https://json-schema.org")
+    parser.add_argument("schema", help="The JSON Schema to use to validate the document")
+    parser.add_argument("document", help="The JSON Document to validate against the schema")
+    args = parser.parse_args()
+
+    with open(args.document) as document_file, open(args.schema) as schema_file:
+        document = json.load(document_file)
+        schema = json.load(schema_file)
+        validate_document_with_schema(document, schema)


### PR DESCRIPTION
# Context
**This is a WIP - not for merging.**

Adding an initial JSON Schema (see https://json-schema.org) for EQ Submission that can be used by downstream systems to validate submission JSON documents.

I have included an example submission for the current v3 branch of eq_survey_runner, noting it doesn't include multiple household members yet and is subject to change.

I added a simple Python script to validate a submission against the schema (you'll need to have installed jsonschema via pip):

`python3 json_validator.py eq_submission_schema.json ../examples/eq_submission_example.json`

The validation patterns are quite loose at the moment (i.e. any text) but I started to narrow some down, any help improving these would be appreciated. Descriptions are missing from a number of elements etc.
