### PR TITLE
Adding send eq data to dap document

### DIFF
--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -44,7 +44,7 @@ Schema Definition
 
         ``exercise_sid``
           The Collection exercise UUID (generated in RM)
-        ``schema_name`` (to replace instrument_id)
+        ``schema_name``
           The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
         ``period``
           A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
@@ -118,9 +118,9 @@ Example Json payloads
         "case_type": "HI",
         "region_code": "GB-ENG",
         "user_id": "1234567890",
-        "channel": "rh"
-        "ru_ref": "47850401631S"
-        "data": [...]
+        "channel": "rh",
+        "ru_ref": "47850401631S",
+        "data": [...],
         "lists": [...]
     }
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -67,7 +67,7 @@ Schema Definition
     The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
   ``channel``
     The channel used to launch the electronic questionnaire (ff | cc | ad | rh)
-  ``metadata``
+  ``metadata`` *TBC: outstanding question around the appropriateness of this name
     A dictionary of data required for the purposes of rendering or routing the given eQ schema
 
         ``display_address``

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -1,9 +1,9 @@
 Electronic Questionnaire to DAP
 ------------------------------------------------
-***Solutions to census requirements are still being designed, implemented, and iterated on.***
-***DST continue to work with PPP to communicate the principles and approaches being taken to deliver these solutions.***
-***As such, the following documentation is subject to change and should be viewed as a living/evolving document.***
-***DST have committed to maintaining this document to reflect the current implementation and, where possible, the target implementation for requirements yet to be delivered.***
+**Solutions to census requirements are still being designed, implemented, and iterated on.**
+**DST continue to work with PPP to communicate the principles and approaches being taken to deliver these solutions.**
+**As such, the following documentation is subject to change and should be viewed as a living/evolving document.**
+**DST have committed to maintaining this document to reflect the current implementation and, where possible, the target implementation for requirements yet to be delivered.**
 
 All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into
 the following described data format for downstream processing and analysis. The json document is encrypted using the
@@ -16,7 +16,7 @@ Low-level datatypes
 
 * All Boolean responses are matched to a "True" or "False" string representation.
 
-* Unanswered optional questions are not be included in submitted responses (i.e null or empty strings values are NOT included)
+* Unanswered optional questions are not included in submitted responses (i.e null or empty strings values are NOT included)
 
 
 Schema Definition
@@ -34,7 +34,7 @@ Schema Definition
   ``survey_id``
     The numerical survey identifier as used across the ONS (e.g census | ccs )
   ``case_id``
-    The case UUID used to identify an instance of a survey response request (generated in RM, may not be included if no case has been linked at submission time)
+    The case UUID used to identify an instance of a survey response request (generated in RM, may not be included if no case has been linked at launch time)
   ``flushed``
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through eQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   ``collection``
@@ -49,7 +49,7 @@ Schema Definition
   ``questionnaire_id``
     A string containing the census Questionnaire ID
   ``response_id``
-    A string contining the RH response_id (a unique value used in part to generate a unique security key, unlikely to be required downstream)
+    A string contining the RH response_id (a unique value used in part to generate a unique security key, unlikely to be required downstream so confirm removal)
   ``started_at``
     The datetime of the first answer saved in a survey
   ``submitted_at``
@@ -71,7 +71,7 @@ Schema Definition
         **list object**
 
         - name: the name of the list (e.g. people-who-live-here)
-        - context: a dictionary of associated information about given items in the list (e.g. primary-person)
+        - context: [optional] a dictionary of any associated information about given items in the list (e.g. primary-person)
         - items: an array of the item identifieres in the list
 
         **lists example**
@@ -97,8 +97,9 @@ Schema Definition
 
         **Dictionary of values**
 
-        - value: The answer given in the questionnaire for the answer.
-        - answer_id: The identifier of the answer.
+        - value: the answer given in the questionnaire for the answer.
+        - answer_id: the identifier of the answer.
+        - list_item_id: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
 
         **Version 0.0.3 data example**
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -85,7 +85,7 @@ Schema Definition
 
         **data object**
 
-        - ``value``: the answer given in the questionnaire for the answer.
+        - ``value``: the value of the answer(s) provided for the answer_id
         - ``answer_id``: the identifier of the answer.
         - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
 
@@ -177,6 +177,45 @@ Example Json payloads
           "value": "Dog",
           "list_item_id": "yuRiRs"
         },
+    ]
+
+.. code-block:: javascript
+
+    "data": [
+        {
+        // example of the list based relationship anwser value array
+        "answer_id": "relationship-answer",
+        "value": [
+            {
+                "from_list_item_id": "tkziBG",
+                "to_list_item_id": "jBlqGM",
+                "relationship": "Husband or Wife"
+            },
+            {
+                "from_list_item_id": "tkziBG",
+                "to_list_item_id": "CEMVLw",
+                "relationship": "Mother or Father"
+            },
+            {
+                "from_list_item_id": "tkziBG",
+                "to_list_item_id": "uknZxD",
+                "relationship": "Mother or Father"
+            },
+            {
+                "from_list_item_id": "jBlqGM",
+                "to_list_item_id": "CEMVLw",
+                "relationship": "Mother or Father"
+            },
+            {
+                "from_list_item_id": "jBlqGM",
+                "to_list_item_id": "uknZxD",
+                "relationship": "Mother or Father"
+            },
+            {
+                "from_list_item_id": "CEMVLw",
+                "to_list_item_id": "uknZxD",
+                "relationship": "Brother or Sister"
+            }
     ]
 
 JWT envelope / transport

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -57,10 +57,6 @@ Schema Definition
     The datetime of the first answer saved in a survey
   ``submitted_at``
     The datetime of submission by the respondent
-  ``ru_ref``
-    The reporting unit reference responsible for the response id (e.g. UPRN)
-  ``user_id``
-    The id assigned by the respondent management system (hardcoded by RH as "1234567890", other channels to provide a staff member's identifier)
   ``case_type``
     The type of case (e.g. HH | HI | CE | CI for census)
   ``region_code``
@@ -70,8 +66,10 @@ Schema Definition
   ``metadata`` *TBC: outstanding question around the appropriateness of this name
     A dictionary of data required for the purposes of rendering or routing the given eQ schema
 
-        ``display_address``
-          The address displayed to the respondent (provided by RH)
+        ``ru_ref``
+          The reporting unit reference responsible for the response id (e.g. UPRN)
+        ``user_id``
+          The id assigned by the respondent management system (hardcoded by RH as empty "", other channels to provide a staff member's identifier)
 
   ``data`` version 0.0.3
     An object containing the response's lists and answers
@@ -115,7 +113,8 @@ Example Json payloads
             "period": "2019"
         },
         "metadata": {
-            "display_address": "68 Argile Avenue, Bath"
+            "user_id": "1234567890",
+            "ru_ref": "47850401631S",
         },
         "response_id": "2111319119395635",
         "questionnaire_id": "4012828663560993",
@@ -123,9 +122,7 @@ Example Json payloads
         "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
         "case_type": "HI",
         "region_code": "GB-ENG",
-        "user_id": "1234567890",
         "channel": "rh",
-        "ru_ref": "47850401631S",
         "data": {
             answers: [...],
             lists: [...]
@@ -138,12 +135,12 @@ Example Json payloads
 
  "lists": [
     {
-     "name": "people-who-live-here",
+     "name": "household",
      "primary_person": "AUZvFL",
      "items": ["AUZvFL", "yuRiRs"]
      },
      {
-      "name": "visitors",
+      "name": "visitor",
       "items": ["vgeYGW"]
      }
  ]
@@ -201,37 +198,37 @@ Example Json payloads
         "value": [
             {
                 // Father's relationship to mother
-                "from_list_item_id": "tkziBG",
+                "list_item_id": "tkziBG",
                 "to_list_item_id": "jBlqGM",
                 "relationship": "Husband or Wife"
             },
             {
                 // Father's relationship to child 1
-                "from_list_item_id": "tkziBG",
+                "list_item_id": "tkziBG",
                 "to_list_item_id": "CEMVLw",
                 "relationship": "Mother or Father"
             },
             {
                 // Father's relationship to child 2
-                "from_list_item_id": "tkziBG",
+                "list_item_id": "tkziBG",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Mother or Father"
             },
             {
                 // Mother's relationship to child 1
-                "from_list_item_id": "jBlqGM",
+                "list_item_id": "jBlqGM",
                 "to_list_item_id": "CEMVLw",
                 "relationship": "Mother or Father"
             },
             {
                 // Mother's relationship to child 2
-                "from_list_item_id": "jBlqGM",
+                "list_item_id": "jBlqGM",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Mother or Father"
             },
             {
                 // Child 1's relationship to child 2
-                "from_list_item_id": "CEMVLw",
+                "list_item_id": "CEMVLw",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Brother or Sister"
             }

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -38,6 +38,7 @@ Schema Definition
   ``flushed``
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through eQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   ``collection``
+    A dictionary of data about the collction exercise the response is for
     ``exercise_sid``
       The Collection exercise UUID (generated in RM)
     ``instrument_id`` (to be replaced with eq_schema)
@@ -63,16 +64,17 @@ Schema Definition
   ``region_code``
     The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
   ``metadata``
+    A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
     ``display_address``
       The address displayed to the respondent (provided by RH)
   ``lists``
-      An array of lists objects built up during the survey completion
+      An array of lists objects built up during the questionnaire completion
 
         **list object**
 
-        - name: the name of the list (e.g. people-who-live-here)
-        - context: [optional] a dictionary of any associated information about given items in the list (e.g. primary-person)
-        - items: an array of the item identifieres in the list
+        - ``name``: the name of the list (e.g. people-who-live-here)
+        - ``context``: [optional] a dictionary of any associated information about given items in the list (e.g. primary-person)
+        - ``items``: an array of the item identifieres in the list
 
         **lists example**
 
@@ -97,9 +99,9 @@ Schema Definition
 
         **Dictionary of values**
 
-        - value: the answer given in the questionnaire for the answer.
-        - answer_id: the identifier of the answer.
-        - list_item_id: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+        - ``value``: the answer given in the questionnaire for the answer.
+        - ``answer_id``: the identifier of the answer.
+        - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
 
         **Version 0.0.3 data example**
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -65,6 +65,8 @@ Schema Definition
     The type of case (e.g. HH | HI | CE | CI for census)
   ``region_code``
     The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
+  ``channel``
+    The channel used to launch the electronic questionnaire (ff | cc | ad | rh)
   ``metadata``
     A dictionary of data required for the purposes of rendering or routing the given eQ schema
 
@@ -116,6 +118,7 @@ Example Json payloads
         "case_type": "HI",
         "region_code": "GB-ENG",
         "user_id": "1234567890",
+        "channel": "rh"
         "ru_ref": "47850401631S"
         "data": [...]
         "lists": [...]

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -44,9 +44,9 @@ Schema Definition
 
         ``exercise_sid``
           The Collection exercise UUID (generated in RM)
-        ``instrument_id`` (to be replaced with eq_schema)
+        ``instrument_id`` (to be replaced with schema_name)
           The Collection Instrument ID (contains the legacy form_type value)
-        ``eq_schema`` (to replace instrument_id)
+        ``schema_name`` (to replace instrument_id)
           The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
         ``period_id``
           A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
@@ -105,7 +105,7 @@ Example Json payloads
         "submitted_at": "2019-06-21T16:37:56.551086",
         "collection": {
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
-            "eq_schema": "census_individual_gb_eng.json",
+            "schema_name": "census_individual_gb_eng.json",
             "period_id": "2019"
         },
         "metadata": {

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -189,10 +189,11 @@ Example Json payloads
           "list_item_id": "yuRiRs"
         },
     ]
+**answers example (list based relationship type)**
 
 .. code-block:: javascript
 
-    "data": [
+    "answers": [
         {
         // example of the list based relationship answser value array
         // based on a mother, father and 2 children

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -40,14 +40,14 @@ Schema Definition
   ``collection``
     A dictionary of data about the collction exercise the response is for
 
-    ``exercise_sid``
-      The Collection exercise UUID (generated in RM)
-    ``instrument_id`` (to be replaced with eq_schema)
-      The Collection Instrument ID (contains the legacy form_type value)
-    ``eq_schema`` (to replace instrument_id)
-      The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
-    ``period_id``
-      A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
+      ``exercise_sid``
+        The Collection exercise UUID (generated in RM)
+      ``instrument_id`` (to be replaced with eq_schema)
+        The Collection Instrument ID (contains the legacy form_type value)
+      ``eq_schema`` (to replace instrument_id)
+        The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
+      ``period_id``
+        A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
 
   ``questionnaire_id``
     A string containing the census Questionnaire ID
@@ -68,8 +68,8 @@ Schema Definition
   ``metadata``
     A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
 
-    ``display_address``
-      The address displayed to the respondent (provided by RH)
+      ``display_address``
+        The address displayed to the respondent (provided by RH)
 
   ``lists``
       An array of lists objects built up during the questionnaire completion

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -74,32 +74,25 @@ Schema Definition
           The address displayed to the respondent (provided by RH)
 
   ``data`` version 0.0.3
+    An object containing the response's lists and answers
 
-        An array containing the response's lists and answers
+        ``lists``
+          An array of list objects built up during the questionnaire completion
 
-        **data object**
+          **list object**
 
-        - ``lists``: the value of the answer(s) provided for the answer_id
-        - ``answers``: the identifier of the answer.
+          - ``name``: the name of the list (e.g. people-who-live-here)
+          - ``items``: an array of strings of the item identifieres in the list
+          - ``primary_person``: [optional] the item identifier of the primary person in the list
 
+        ``answers``
+          A sorted array* of answer objects
 
-        - ``lists``
-                An array of list objects built up during the questionnaire completion
+          **answer object**
 
-                **list object**
-
-                - ``name``: the name of the list (e.g. people-who-live-here)
-                - ``items``: an array of strings of the item identifieres in the list
-                - ``primary_person``: [optional] the item identifier of the primary person in the list
-
-        - ``answers``
-                A sorted array* of answers in the order the questionnaire was answered [*to be confirmed this is correct]
-
-                **answer object**
-
-                - ``value``: the value of the answer(s) provided for the answer_id
-                - ``answer_id``: the identifier of the answer.
-                - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+          - ``value``: the value of the answer(s) provided for the answer_id
+          - ``answer_id``: the identifier of the answer.
+          - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
 
 
 
@@ -133,8 +126,10 @@ Example Json payloads
         "user_id": "1234567890",
         "channel": "rh",
         "ru_ref": "47850401631S",
-        "data": [...],
-        "lists": [...]
+        "data": {
+            answers: [...],
+            lists: [...]
+        }
     }
 
 **lists example**
@@ -153,11 +148,11 @@ Example Json payloads
      }
  ]
 
-**data example** version 0.0.3
+**answers example**
 
 .. code-block:: javascript
 
-    "data": [
+    "answers": [
         {
           // Example of a free text input box question
           "value": "piloting space shuttles",

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -49,7 +49,7 @@ Schema Definition
     ``period_id``
       A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
 
-``questionnaire_id``
+  ``questionnaire_id``
     A string containing the census Questionnaire ID
   ``response_id``
     A string contining the RH response_id (a unique value used in part to generate a unique security key, unlikely to be required downstream so confirm removal)

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -44,11 +44,9 @@ Schema Definition
 
         ``exercise_sid``
           The Collection exercise UUID (generated in RM)
-        ``instrument_id`` (to be replaced with schema_name)
-          The Collection Instrument ID (contains the legacy form_type value)
         ``schema_name`` (to replace instrument_id)
           The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
-        ``period_id``
+        ``period``
           A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
 
   ``questionnaire_id``
@@ -106,7 +104,7 @@ Example Json payloads
         "collection": {
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "census_individual_gb_eng.json",
-            "period_id": "2019"
+            "period": "2019"
         },
         "metadata": {
             "display_address": "68 Argile Avenue, Bath"

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -39,6 +39,7 @@ Schema Definition
     Whether the survey was flushed or not. This will be `true` if the survey has been flushed through eQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
   ``collection``
     A dictionary of data about the collction exercise the response is for
+
     ``exercise_sid``
       The Collection exercise UUID (generated in RM)
     ``instrument_id`` (to be replaced with eq_schema)
@@ -65,6 +66,7 @@ Schema Definition
     The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
   ``metadata``
     A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
+
     ``display_address``
       The address displayed to the respondent (provided by RH)
   ``lists``

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -40,15 +40,16 @@ Schema Definition
   ``collection``
     A dictionary of data about the collction exercise the response is for
 
-    - ``exercise_sid``
+    ``exercise_sid``
       The Collection exercise UUID (generated in RM)
-    - ``instrument_id`` (to be replaced with eq_schema)
+    ``instrument_id`` (to be replaced with eq_schema)
       The Collection Instrument ID (contains the legacy form_type value)
-    - ``eq_schema`` (to replace instrument_id)
+    ``eq_schema`` (to replace instrument_id)
       The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
-    - ``period_id``
+    ``period_id``
       A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
-  ``questionnaire_id``
+
+``questionnaire_id``
     A string containing the census Questionnaire ID
   ``response_id``
     A string contining the RH response_id (a unique value used in part to generate a unique security key, unlikely to be required downstream so confirm removal)
@@ -67,8 +68,9 @@ Schema Definition
   ``metadata``
     A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
 
-    - ``display_address``
+    ``display_address``
       The address displayed to the respondent (provided by RH)
+
   ``lists``
       An array of lists objects built up during the questionnaire completion
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -73,23 +73,36 @@ Schema Definition
         ``display_address``
           The address displayed to the respondent (provided by RH)
 
-  ``lists``
-        An array of list objects built up during the questionnaire completion
-
-        **list object**
-
-        - ``name``: the name of the list (e.g. people-who-live-here)
-        - ``context``: [optional] a dictionary of any associated information about given items in the list (e.g. primary-person)
-        - ``items``: an array of the item identifieres in the list
-
   ``data`` version 0.0.3
-        A sorted array* of answers in the order the questionnaire was answered [*to be confirmed this is correct]
+
+        An array containing the response's lists and answers
 
         **data object**
 
-        - ``value``: the value of the answer(s) provided for the answer_id
-        - ``answer_id``: the identifier of the answer.
-        - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+        - ``lists``: the value of the answer(s) provided for the answer_id
+        - ``answers``: the identifier of the answer.
+
+
+        - ``lists``
+                An array of list objects built up during the questionnaire completion
+
+                **list object**
+
+                - ``name``: the name of the list (e.g. people-who-live-here)
+                - ``items``: an array of strings of the item identifieres in the list
+                - ``primary_person``: [optional] the item identifier of the primary person in the list
+
+        - ``answers``
+                A sorted array* of answers in the order the questionnaire was answered [*to be confirmed this is correct]
+
+                **answer object**
+
+                - ``value``: the value of the answer(s) provided for the answer_id
+                - ``answer_id``: the identifier of the answer.
+                - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+
+
+
 
 Example Json payloads
 =====================
@@ -131,7 +144,7 @@ Example Json payloads
  "lists": [
     {
      "name": "people-who-live-here",
-     "context": {"primary_person": "AUZvFL"},
+     "primary_person": "AUZvFL",
      "items": ["AUZvFL", "yuRiRs"]
      },
      {

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -40,13 +40,13 @@ Schema Definition
   ``collection``
     A dictionary of data about the collction exercise the response is for
 
-    ``exercise_sid``
+    - ``exercise_sid``
       The Collection exercise UUID (generated in RM)
-    ``instrument_id`` (to be replaced with eq_schema)
+    - ``instrument_id`` (to be replaced with eq_schema)
       The Collection Instrument ID (contains the legacy form_type value)
-    ``eq_schema`` (to replace instrument_id)
+    - ``eq_schema`` (to replace instrument_id)
       The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
-    ``period_id``
+    - ``period_id``
       A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
   ``questionnaire_id``
     A string containing the census Questionnaire ID
@@ -67,7 +67,7 @@ Schema Definition
   ``metadata``
     A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
 
-    ``display_address``
+    - ``display_address``
       The address displayed to the respondent (provided by RH)
   ``lists``
       An array of lists objects built up during the questionnaire completion

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -1,0 +1,174 @@
+Electronic Questionnaire to DAP
+------------------------------------------------
+All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into
+the following described data format for downstream processing and analysis. The json document is encrypted using the
+public key of the downstream transport mechanimn at submission, placing the cyphertext onto message queue for downstream consumption
+
+Low-level datatypes
+===================
+* All datetimes are expressed using ISO_8601 and are assumed to be normalised to UTC unless a timezone identifier is given. All
+  character encoding is UTF-8.
+
+* All Boolean responses are matched to a "True" or "False" string representation.
+
+* Uanswered optional questions will not be included in submitted responses (i.e null or empty strings values are NOT included)
+
+
+Schema Definition
+=================
+
+  tx_id
+     Transaction ID used to trace a transaction through the whole system. This will be a GUID (version 4) and 128-bits in length as defined in RFC 4122 in its textual representation as defined in section 3 "Namespace Registration Template" without the "urn:uuid:" prefix e.g. "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
+  type
+    The unique type identifier of this JSON file.
+    Can be "uk.gov.ons.edc.eq:surveyresponse" or "uk.gov.ons.edc.eq:feedback"
+  version
+    The version number of the schema definition used to generate and parse the
+    schema. Will always be 3 numbers separated by two dots e.g. "0.0.3" with the
+    intention being MAJOR.MINOR.PATCH no guarantees are given to compatibility
+    across version changes.
+  origin
+    The name or identifier of the data capture / data generator system. Currently "uk.gov.ons.edc.eq" - however this allows us to
+    futureproof for new collection instruments.
+  survey_id
+    The numerical survey identifier as used across the ONS.
+  case_id
+    The case UUID used to identify a single instance of a survey collection for a respondent [optional]
+  flushed
+    Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
+  collection
+    exercise_sid
+      Collection exercise ID
+    instrument_id (replace with eq_schema/eq_schema_id for ceneus and beyond !!!)
+      The collection instrument ID - used by legacy downstream systems (contains the form_type!)
+    period_id (rename from period and move to required runner metadata.. include or not for ceneus ??????)
+      A string representing the collection period
+  questionnaire_id
+    A string containing the census Questionnaire ID
+  response_id
+    A string contining the RH response_id (not required ?)
+  started_at
+    The datetime of the first answer saved in a survey
+  submitted_at
+    The datetime of submission by the respondent.
+  metadata
+    user_id
+      The respondent user_id as specified by the channel in use (this will be the identifier of the staff operator)
+    ru_ref
+      Reporting Unit reference number to which the collected data represents. This
+      allows the downstream system to map the responses to individual business/household/person
+      in the original sample as created by the survey team.
+  lists
+      An array of lists objects built up during the survey completion
+
+        **list object**
+
+        - name: the name of the list (e.g. people-who-live-here)
+        - context: a dictionary of associated information about given items in the list (e.g. primary-person)
+        - items: an array of the item identifieres in the list
+
+        **lists example**
+
+         .. code-block:: javascript
+
+            "lists": [
+                {
+                 "name": "people-who-live-here",
+                 "context": {"primary_person": "AUZvFL"},
+                 "items": ["AUZvFL", "yuRiRs"]
+                 },
+                 {
+                  "name": "visitors",
+                  "items": ["vgeYGW"]
+                 }
+            ]
+
+
+  data
+    Version 0.0.3
+        A sorted array of answers in the order the questionnaire was answered* [Is this correct???????????????].
+
+        **Dictionary of values**
+
+        - value: The answer given in the questionnaire for the answer.
+        - answer_id: The identifier of the answer.
+
+        **Version 0.0.3 data example**
+
+        .. code-block:: javascript
+
+            "data": [
+                {
+                  // Example of a free text input box question
+                  "value": "piloting space shuttles",
+                  "answer_id": "job-description-answer",
+                },
+                {
+                  // Example of a single value for a radio button question
+                  "answer_id": "marriage-type-answer",
+                  "value": "Married"
+                },
+                {
+                  // Example of multiple values for a checkbox question
+                  "value": ["Eggs", "Bacon", "Spam"],
+                  "answer_id": "favourite-breakfast-food",
+                }
+                {
+                  "answer_id": "first-name",
+                  "value": "Colin",
+                  "list_item_id": "AUZvFL"
+                },
+                {
+                  "answer_id": "last-name",
+                  "value": "Cat",
+                  "list_item_id": "AUZvFL"
+                },
+                {
+                  "answer_id": "first-name",
+                  "value": "Dave",
+                  "list_item_id": "yuRiRs"
+                },
+                {
+                  "answer_id": "last-name",
+                  "value": "Dog",
+                  "list_item_id": "yuRiRs"
+                },
+            ]
+
+
+
+
+Example Json payloads
+=====================
+
+.. code-block:: javascript
+
+   {
+        "tx_id": "ea82c224-0f80-41cc-b877-8a7804b56c26",
+        "type": "uk.gov.ons.edc.eq:surveyresponse",
+        "version": "0.0.3",
+        "origin": "uk.gov.ons.edc.eq",
+        "survey_id": "census",
+        "flushed": false,
+        "submitted_at": "2019-06-21T16:37:56.551086",
+        "collection": {
+            "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
+            "eq_schema": "census_individual_gb_eng.json",
+            "period_id": "2019"
+        },
+        "metadata": {
+            "user_id": "1234567890",
+            "ru_ref": "47850401631S"
+        },
+        "response_id": "2111319119395635",
+        "questionnaire_id": "4012828663560993",
+        "started_at": "2019-06-21T16:33:30.665144",
+        "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
+        "data": [...]
+        "lists": [...]
+    }
+    
+
+JWT envelope / transport
+========================
+This payload is part of a JWT as specified in :doc:`jwt_profile`.

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -86,7 +86,7 @@ Schema Definition
           - ``primary_person``: [optional] the item identifier of the primary person in the list
 
         ``answers``
-          A sorted array* of answer objects
+          A sorted array of answer objects
 
           **answer object**
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -183,35 +183,42 @@ Example Json payloads
 
     "data": [
         {
-        // example of the list based relationship anwser value array
+        // example of the list based relationship answser value array
+        // based on a mother, father and 2 children
         "answer_id": "relationship-answer",
         "value": [
             {
+                // Father's relationship to mother
                 "from_list_item_id": "tkziBG",
                 "to_list_item_id": "jBlqGM",
                 "relationship": "Husband or Wife"
             },
             {
+                // Father's relationship to child 1
                 "from_list_item_id": "tkziBG",
                 "to_list_item_id": "CEMVLw",
                 "relationship": "Mother or Father"
             },
             {
+                // Father's relationship to child 2
                 "from_list_item_id": "tkziBG",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Mother or Father"
             },
             {
+                // Mother's relationship to child 1
                 "from_list_item_id": "jBlqGM",
                 "to_list_item_id": "CEMVLw",
                 "relationship": "Mother or Father"
             },
             {
+                // Mother's relationship to child 2
                 "from_list_item_id": "jBlqGM",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Mother or Father"
             },
             {
+                // Child 1's relationship to child 2
                 "from_list_item_id": "CEMVLw",
                 "to_list_item_id": "uknZxD",
                 "relationship": "Brother or Sister"

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -72,7 +72,7 @@ Schema Definition
         The address displayed to the respondent (provided by RH)
 
   ``lists``
-      An array of lists objects built up during the questionnaire completion
+        An array of list objects built up during the questionnaire completion
 
         **list object**
 
@@ -80,81 +80,17 @@ Schema Definition
         - ``context``: [optional] a dictionary of any associated information about given items in the list (e.g. primary-person)
         - ``items``: an array of the item identifieres in the list
 
-        **lists example**
+  ``data`` version 0.0.3
+        A sorted array* of answers in the order the questionnaire was answered [*to be confirmed this is correct]
 
-         .. code-block:: javascript
-
-            "lists": [
-                {
-                 "name": "people-who-live-here",
-                 "context": {"primary_person": "AUZvFL"},
-                 "items": ["AUZvFL", "yuRiRs"]
-                 },
-                 {
-                  "name": "visitors",
-                  "items": ["vgeYGW"]
-                 }
-            ]
-
-
-  ``data``
-    Version 0.0.3
-        A sorted array of answers in the order the questionnaire was answered* [Is this correct???????????????].
-
-        **Dictionary of values**
+        **data object**
 
         - ``value``: the answer given in the questionnaire for the answer.
         - ``answer_id``: the identifier of the answer.
         - ``list_item_id``: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
 
-        **Version 0.0.3 data example**
-
-        .. code-block:: javascript
-
-            "data": [
-                {
-                  // Example of a free text input box question
-                  "value": "piloting space shuttles",
-                  "answer_id": "job-description-answer",
-                },
-                {
-                  // Example of a single value for a radio button question
-                  "answer_id": "marriage-type-answer",
-                  "value": "Married"
-                },
-                {
-                  // Example of multiple values for a checkbox question
-                  "value": ["Eggs", "Bacon", "Spam"],
-                  "answer_id": "favourite-breakfast-food",
-                }
-                {
-                  "answer_id": "first-name",
-                  "value": "Colin",
-                  "list_item_id": "AUZvFL"
-                },
-                {
-                  "answer_id": "last-name",
-                  "value": "Cat",
-                  "list_item_id": "AUZvFL"
-                },
-                {
-                  "answer_id": "first-name",
-                  "value": "Dave",
-                  "list_item_id": "yuRiRs"
-                },
-                {
-                  "answer_id": "last-name",
-                  "value": "Dog",
-                  "list_item_id": "yuRiRs"
-                },
-            ]
-
-
-
-
 Example Json payloads
 =====================
-
 .. code-block:: javascript
 
    {
@@ -184,7 +120,64 @@ Example Json payloads
         "data": [...]
         "lists": [...]
     }
-    
+
+**lists example**
+
+.. code-block:: javascript
+
+ "lists": [
+    {
+     "name": "people-who-live-here",
+     "context": {"primary_person": "AUZvFL"},
+     "items": ["AUZvFL", "yuRiRs"]
+     },
+     {
+      "name": "visitors",
+      "items": ["vgeYGW"]
+     }
+ ]
+
+**data example** version 0.0.3
+
+.. code-block:: javascript
+
+    "data": [
+        {
+          // Example of a free text input box question
+          "value": "piloting space shuttles",
+          "answer_id": "job-description-answer",
+        },
+        {
+          // Example of a single value for a radio button question
+          "answer_id": "marriage-type-answer",
+          "value": "Married"
+        },
+        {
+          // Example of multiple values for a checkbox question
+          "value": ["Eggs", "Bacon", "Spam"],
+          "answer_id": "favourite-breakfast-food",
+        }
+        {
+          "answer_id": "first-name",
+          "value": "Colin",
+          "list_item_id": "AUZvFL"
+        },
+        {
+          "answer_id": "last-name",
+          "value": "Cat",
+          "list_item_id": "AUZvFL"
+        },
+        {
+          "answer_id": "first-name",
+          "value": "Dave",
+          "list_item_id": "yuRiRs"
+        },
+        {
+          "answer_id": "last-name",
+          "value": "Dog",
+          "list_item_id": "yuRiRs"
+        },
+    ]
 
 JWT envelope / transport
 ========================

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -1,8 +1,13 @@
 Electronic Questionnaire to DAP
 ------------------------------------------------
+***Solutions to census requirements are still being designed, implemented, and iterated on.***
+***DST continue to work with PPP to communicate the principles and approaches being taken to deliver these solutions.***
+***As such, the following documentation is subject to change and should be viewed as a living/evolving document.***
+***DST have committed to maintaining this document to reflect the current implementation and, where possible, the target implementation for requirements yet to be delivered.***
+
 All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into
 the following described data format for downstream processing and analysis. The json document is encrypted using the
-public key of the downstream transport mechanimn at submission, placing the cyphertext onto message queue for downstream consumption
+public key of the downstream transport mechanism at submission, placing the cyphertext onto a message queue for downstream consumption.
 
 Low-level datatypes
 ===================
@@ -11,54 +16,56 @@ Low-level datatypes
 
 * All Boolean responses are matched to a "True" or "False" string representation.
 
-* Uanswered optional questions will not be included in submitted responses (i.e null or empty strings values are NOT included)
+* Unanswered optional questions are not be included in submitted responses (i.e null or empty strings values are NOT included)
 
 
 Schema Definition
 =================
 
-  tx_id
-     Transaction ID used to trace a transaction through the whole system. This will be a GUID (version 4) and 128-bits in length as defined in RFC 4122 in its textual representation as defined in section 3 "Namespace Registration Template" without the "urn:uuid:" prefix e.g. "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
-  type
+  ``tx_id``
+     Transaction ID used to trace a transaction through the collection system. This will be a UUID (version 4) and 128-bits in length as defined in RFC 4122 in its textual representation as defined in section 3 "Namespace Registration Template" without the "urn:uuid:" prefix e.g. "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
+  ``type``
     The unique type identifier of this JSON file.
     Can be "uk.gov.ons.edc.eq:surveyresponse" or "uk.gov.ons.edc.eq:feedback"
-  version
-    The version number of the schema definition used to generate and parse the
-    schema. Will always be 3 numbers separated by two dots e.g. "0.0.3" with the
-    intention being MAJOR.MINOR.PATCH no guarantees are given to compatibility
-    across version changes.
-  origin
-    The name or identifier of the data capture / data generator system. Currently "uk.gov.ons.edc.eq" - however this allows us to
-    futureproof for new collection instruments.
-  survey_id
-    The numerical survey identifier as used across the ONS.
-  case_id
-    The case UUID used to identify a single instance of a survey collection for a respondent [optional]
-  flushed
-    Whether the survey was flushed or not. This will be `true` if the survey has been flushed through EQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
-  collection
-    exercise_sid
-      Collection exercise ID
-    instrument_id (replace with eq_schema/eq_schema_id for ceneus and beyond !!!)
-      The collection instrument ID - used by legacy downstream systems (contains the form_type!)
-    period_id (rename from period and move to required runner metadata.. include or not for ceneus ??????)
-      A string representing the collection period
-  questionnaire_id
+  ``version``
+    The version number of the eQ data payload structure (e.g. "0.0.3" for census)
+  ``origin``
+    The name or identifier of the data capture system. Currently "uk.gov.ons.edc.eq" (historical named for Electronic Data Collection)
+  ``survey_id``
+    The numerical survey identifier as used across the ONS (e.g census | ccs )
+  ``case_id``
+    The case UUID used to identify an instance of a survey response request (generated in RM, may not be included if no case has been linked at submission time)
+  ``flushed``
+    Whether the survey was flushed or not. This will be `true` if the survey has been flushed through eQ (surveys that haven't been submitted could be flushed through at the end of their collection period) and `false` otherwise.
+  ``collection``
+    ``exercise_sid``
+      The Collection exercise UUID (generated in RM)
+    ``instrument_id`` (to be replaced with eq_schema)
+      The Collection Instrument ID (contains the legacy form_type value)
+    ``eq_schema`` (to replace instrument_id)
+      The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
+    ``period_id``
+      A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
+  ``questionnaire_id``
     A string containing the census Questionnaire ID
-  response_id
-    A string contining the RH response_id (not required ?)
-  started_at
+  ``response_id``
+    A string contining the RH response_id (a unique value used in part to generate a unique security key, unlikely to be required downstream)
+  ``started_at``
     The datetime of the first answer saved in a survey
-  submitted_at
-    The datetime of submission by the respondent.
-  metadata
-    user_id
-      The respondent user_id as specified by the channel in use (this will be the identifier of the staff operator)
-    ru_ref
-      Reporting Unit reference number to which the collected data represents. This
-      allows the downstream system to map the responses to individual business/household/person
-      in the original sample as created by the survey team.
-  lists
+  ``submitted_at``
+    The datetime of submission by the respondent
+  ``ru_ref``
+    The reporting unit reference responsible for the response id (e.g. UPRN)
+  ``user_id``
+    The id assigned by the respondent management system (hardcoded by RH as "1234567890", other channels to provide a staff member's identifier)
+  ``case_type``
+    The type of Census case (HH | HI | CE | CI)
+  ``region_code``
+    The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
+  ``metadata``
+    ``display_address``
+      The address displayed to the respondent (provided by RH)
+  ``lists``
       An array of lists objects built up during the survey completion
 
         **list object**
@@ -84,7 +91,7 @@ Schema Definition
             ]
 
 
-  data
+  ``data``
     Version 0.0.3
         A sorted array of answers in the order the questionnaire was answered* [Is this correct???????????????].
 
@@ -157,13 +164,16 @@ Example Json payloads
             "period_id": "2019"
         },
         "metadata": {
-            "user_id": "1234567890",
-            "ru_ref": "47850401631S"
+            "display_address": "68 Argile Avenue, Bath"
         },
         "response_id": "2111319119395635",
         "questionnaire_id": "4012828663560993",
         "started_at": "2019-06-21T16:33:30.665144",
         "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
+        "case_type": "HI",
+        "region_code": "GB-ENG",
+        "user_id": "1234567890",
+        "ru_ref": "47850401631S"
         "data": [...]
         "lists": [...]
     }

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -1,13 +1,13 @@
 Electronic Questionnaire to DAP
 ------------------------------------------------
 **Solutions to census requirements are still being designed, implemented, and iterated on.**
-**DST continue to work with PPP to communicate the principles and approaches being taken to deliver these solutions.**
+**DST continue to work with colleagues from MDR and PPP to communicate the principles and approaches being taken to deliver these solutions.**
 **As such, the following documentation is subject to change and should be viewed as a living/evolving document.**
 **DST have committed to maintaining this document to reflect the current implementation and, where possible, the target implementation for requirements yet to be delivered.**
 
 All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into the following described data format for downstream processing and analysis.
 
-The data structures created by eQ (e.g the answer store) are designed and optimised primarily for the purposes of generic functionality within the survey runner product. As a general principle, the extent of the transform carried out by eQ over and above its native data models is minimal. It is not the responsibility of the eQ product to carry out bespoke data transforms. Historically SDX has been responsible for more extensive and complex data transforms.
+The data structures created by eQ (e.g the answer store) are designed and optimised primarily for the purposes of generic functionality within the survey runner product. As a general principle, the extent of the transform carried out by eQ on submitted response data beyond its native data models is minimal. It is not the responsibility of the eQ product to carry out bespoke data transforms. Historically SDX has been responsible for more extensive and complex data transforms.
 
 The json document is encrypted using the public key of the downstream transport mechanism at submission, placing the cyphertext onto a message queue for downstream consumption.
 

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -5,9 +5,11 @@ Electronic Questionnaire to DAP
 **As such, the following documentation is subject to change and should be viewed as a living/evolving document.**
 **DST have committed to maintaining this document to reflect the current implementation and, where possible, the target implementation for requirements yet to be delivered.**
 
-All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into
-the following described data format for downstream processing and analysis. The json document is encrypted using the
-public key of the downstream transport mechanism at submission, placing the cyphertext onto a message queue for downstream consumption.
+All submitted responses for a collection exercise (a questionnaire within a survey series) are transformed into the following described data format for downstream processing and analysis.
+
+The data structures created by eQ (e.g the answer store) are designed and optimised primarily for the purposes of generic functionality within the survey runner product. As a general principle, the extent of the transform carried out by eQ over and above its native data models is minimal. It is not the responsibility of the eQ product to carry out bespoke data transforms. Historically SDX has been responsible for more extensive and complex data transforms.
+
+The json document is encrypted using the public key of the downstream transport mechanism at submission, placing the cyphertext onto a message queue for downstream consumption.
 
 Low-level datatypes
 ===================
@@ -23,7 +25,7 @@ Schema Definition
 =================
 
   ``tx_id``
-     Transaction ID used to trace a transaction through the collection system. This will be a UUID (version 4) and 128-bits in length as defined in RFC 4122 in its textual representation as defined in section 3 "Namespace Registration Template" without the "urn:uuid:" prefix e.g. "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
+    Transaction ID used to trace a transaction through the collection system. This will be a UUID (version 4) and 128-bits in length as defined in RFC 4122 in its textual representation as defined in section 3 "Namespace Registration Template" without the "urn:uuid:" prefix e.g. "f81d4fae-7dec-11d0-a765-00a0c91e6bf6".
   ``type``
     The unique type identifier of this JSON file.
     Can be "uk.gov.ons.edc.eq:surveyresponse" or "uk.gov.ons.edc.eq:feedback"
@@ -40,13 +42,13 @@ Schema Definition
   ``collection``
     A dictionary of data about the collction exercise the response is for
 
-      ``exercise_sid``
+        ``exercise_sid``
         The Collection exercise UUID (generated in RM)
-      ``instrument_id`` (to be replaced with eq_schema)
+        ``instrument_id`` (to be replaced with eq_schema)
         The Collection Instrument ID (contains the legacy form_type value)
-      ``eq_schema`` (to replace instrument_id)
+        ``eq_schema`` (to replace instrument_id)
         The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
-      ``period_id``
+        ``period_id``
         A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
 
   ``questionnaire_id``
@@ -62,13 +64,13 @@ Schema Definition
   ``user_id``
     The id assigned by the respondent management system (hardcoded by RH as "1234567890", other channels to provide a staff member's identifier)
   ``case_type``
-    The type of Census case (HH | HI | CE | CI)
+    The type of case (e.g. HH | HI | CE | CI for census)
   ``region_code``
     The Region Code of the questionnaire response. Format as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:GB) i.e. GB-ENG | GB-WLS | GB-NIR
   ``metadata``
-    A dictionary of metadata provided for the purposes of rendering or routing the eQ schema
+    A dictionary of data required for the purposes of rendering or routing the given eQ schema
 
-      ``display_address``
+        ``display_address``
         The address displayed to the respondent (provided by RH)
 
   ``lists``

--- a/docs/electronic_questionnaire_to_dap.rst
+++ b/docs/electronic_questionnaire_to_dap.rst
@@ -43,13 +43,13 @@ Schema Definition
     A dictionary of data about the collction exercise the response is for
 
         ``exercise_sid``
-        The Collection exercise UUID (generated in RM)
+          The Collection exercise UUID (generated in RM)
         ``instrument_id`` (to be replaced with eq_schema)
-        The Collection Instrument ID (contains the legacy form_type value)
+          The Collection Instrument ID (contains the legacy form_type value)
         ``eq_schema`` (to replace instrument_id)
-        The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
+          The eQ schema representing the question set presented to the respondent (e.g. census_individual_gb_eng.json)
         ``period_id``
-        A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
+          A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey (currently hardcoded by RH as 1, to be changed to "2019")
 
   ``questionnaire_id``
     A string containing the census Questionnaire ID
@@ -71,7 +71,7 @@ Schema Definition
     A dictionary of data required for the purposes of rendering or routing the given eQ schema
 
         ``display_address``
-        The address displayed to the respondent (provided by RH)
+          The address displayed to the respondent (provided by RH)
 
   ``lists``
         An array of list objects built up during the questionnaire completion

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Contents:
    start
    jwt_profile
    respondent_management_to_electronic_questionnaire
-   electronic_questionnaire_to_data_exchange
+   electronic_questionnaire_to_dap
    survey_data_exchange_to_respondent_account_services
 
 


### PR DESCRIPTION
New schema definition to reflect the current 0.0.3 response object for census data to DAP

https://github.com/ONSdigital/ons-schema-definitions/blob/adding_send_eq_data_to_dap_document/docs/electronic_questionnaire_to_dap.rst