### PR TITLE
Adding display_address to the submission schema

### DIFF
--- a/examples/eq_submission_example.json
+++ b/examples/eq_submission_example.json
@@ -21,6 +21,7 @@
     "region_code": "GB-ENG",
     "started_at": "2019-08-20T11:05:25.604330",
     "case_id": "6453e4d3-aac1-424c-be28-23c57aa9e17d",
+    "display_address": "1 Road, Town City",
     "data": {
         "answers": [
             {

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -20,6 +20,7 @@
     "region_code",
     "started_at",
     "case_id",
+    "display_address",
     "data"
   ],
   "properties": {
@@ -248,6 +249,16 @@
         "5515cd5f-fcff-44f0-ac02-3530477693ea"
       ],
       "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+    },
+    "display_address": {
+      "$id": "#/properties/display_address",
+      "type": "string",
+      "title": "Display Address",
+      "default": "",
+      "examples": [
+        "68 Abingdon Road, Goathill"
+      ],
+      "pattern": "^(.*)$"
     },
     "data": {
       "$id": "#/properties/data",


### PR DESCRIPTION
# Context
The 'display_address' claim was recently added to the downstream submission data from EQ Survey Runner. I have added this claim to the EQ Submission Schema JSON file.

# How to Review
Check that the EQ Submission Schema JSON contains the 'display_address' claim. 

I have also added the 'display_address' claim to the example submission JSON, so ensure that this example schema (/examples/eq_submission_example.json) is still being validated by running:

```pipenv run python ./schemas/json_validator.py ./schemas/eq_submission_schema.json ./examples/eq_submission_example.json```