### PR TITLE
Removing type validation for answer values

### DIFF
--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -296,13 +296,11 @@
               },
               "value": {
                 "$id": "#/properties/data/properties/answers/items/properties/value",
-                "type": ["string", "array"],
                 "title": "The response value",
                 "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
                 "default": "",
                 "items": {
                   "$id": "#/properties/data/properties/answers/items/properties/value/items",
-                  "type": "object",
                   "examples": [
                   "Christian",
                   "Buddhist",


### PR DESCRIPTION
# Context
We have removed 'type' validation for answer values and answer value list items as we want to be able to handle any/all answer value types. We do not want any issues for downstream processes resulting from failures validating answer types.

# How to Review
Add new answer value types or amend the existing answer value types in the example submission schema (eq_submission_example.json). For example, replace one of the answer value strings with an integer. 

Ensure that the new example schema is still able to be validated by running:
```pipenv run python ./schemas/json_validator.py ./schemas/eq_submission_schema.json ./examples/eq_submission_example.json```