### PR TITLE
Add additional data structures and extra submission examples

### DIFF
--- a/examples/eq_submission_example.json
+++ b/examples/eq_submission_example.json
@@ -20,7 +20,6 @@
     "questionnaire_id": "9150293245728665",
     "launch_language_code": "en",
     "submission_language_code": "cy",
-    "case_type": "HI",
     "region_code": "GB-ENG",
     "started_at": "2019-08-20T11:05:25.604330",
     "case_id": "6453e4d3-aac1-424c-be28-23c57aa9e17d",
@@ -51,14 +50,56 @@
                 "value": "No"
             },
             {
+                "answer_id": "number-of-bedrooms-answer",
+                "value": 4
+            },
+            {
+                "answer_id": "date-of-birth-answer",
+                "value": "1990-01-01",
+                "list_item_id": "EINoLs"
+            },
+            {
+                "answer_id": "internet-answer",
+                "value": [
+                    "Broadband or WiFi",
+                    "A mobile phone network such as 3G, 4G or 5G",
+                    "Public WiFi hotspot"
+                ]
+            },
+            {
+                "answer_id": "business-type-answer",
+                "value": "Enter Business type here!",
+                 "list_item_id": "EINoLs"
+            },
+            {
                 "answer_id": "relationship-answer",
                 "value": [
                     {
                         "list_item_id": "zGBdpb",
                         "to_list_item_id": "cWGwcF",
                         "relationship": "Husband or Wife"
+                    },
+                    {
+                         "list_item_id": "nEMpwe",
+                        "to_list_item_id": "adNCSi",
+                        "relationship": "Son or daughter"
+                    },
+                    {
+                        "list_item_id": "ukGiCK",
+                        "to_list_item_id": "adNCSi",
+                        "relationship": "Mother or father"
                     }
                 ]
+            },
+            {
+                "answer_id": "other-address-uk-answer",
+                "value": {
+                    "line1": "Address Line 1",
+                    "town": "Town",
+                    "postcode": "NP10 8XG",
+                    "uprn": "12345678912"
+                },
+                "list_item_id": "cWGwcF"
             }
         ],
         "lists": [

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -382,15 +382,23 @@
                                   }
                               ],
                               "required": [
-                                  "line1",
-                                  "town",
-                                  "postcode"
+                                  "line1"
                               ],
                               "properties": {
                                   "line1": {
                                       "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/line1",
                                       "type": "string",
                                       "title": "Address line 1",
+                                      "default": "",
+                                      "examples": [
+                                          "1 Example Street"
+                                      ],
+                                      "pattern": "^(.*)$"
+                                  },
+                                  "line2": {
+                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/line2",
+                                      "type": "string",
+                                      "title": "Address line 2",
                                       "default": "",
                                       "examples": [
                                           "1 Example Street"

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -14,10 +14,8 @@
     "submitted_at",
     "collection",
     "metadata",
-    "response_id",
     "questionnaire_id",
     "launch_language_code",
-    "case_type",
     "region_code",
     "started_at",
     "case_id",
@@ -186,16 +184,6 @@
         }
       }
     },
-    "response_id": {
-      "$id": "#/properties/response_id",
-      "type": "string",
-      "title": "Response ID",
-      "default": "",
-      "examples": [
-        "3387746373631872"
-      ],
-      "pattern": "^(.*)$"
-    },
     "questionnaire_id": {
       "$id": "#/properties/questionnaire_id",
       "type": "string",
@@ -225,16 +213,6 @@
         "cy"
       ],
       "pattern": "^(.*)$"
-    },
-    "case_type": {
-      "$id": "#/properties/case_type",
-      "type": "string",
-      "enum": ["HH", "HI", "CE", "CI"],
-      "title": "Case Type",
-      "default": "",
-      "examples": [
-        "HI"
-      ]
     },
     "region_code": {
       "$id": "#/properties/region_code",
@@ -295,54 +273,264 @@
           "type": "array",
           "title": "Answer",
           "items": {
-            "$id": "#/properties/data/properties/answers/items",
-            "type": "object",
-            "title": "The answers submitted",
-            "required": [
-              "answer_id",
-              "value"
-            ],
-            "properties": {
-              "answer_id": {
-                "$id": "#/properties/data/properties/answers/items/properties/answer_id",
-                "type": "string",
-                "title": "Answer ID",
-                "default": "",
-                "examples": [
-                  "accommodation-type-answer",
-                  "first-name",
-                  "ethnic-group-answer"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "value": {
-                "$id": "#/properties/data/properties/answers/items/properties/value",
-                "title": "The response value",
-                "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
-                "default": "",
-                "items": {
-                  "$id": "#/properties/data/properties/answers/items/properties/value/items",
-                  "examples": [
-                  "Christian",
-                  "Buddhist",
-                  "Yes",
-                  "No"
-                ]
-                },
-                "pattern": "^(.*)$"
-              },
-              "list_item_id": {
-                "$id": "#/properties/data/properties/answers/items/properties/list_item_id",
-                "type": "string",
-                "title": "List Item ID",
-                "description": "Related item will have the same ID e.g. first name and last name for the same person",
-                "default": "",
-                "examples": [
-                  "zGBdpb"
-                ],
-                "pattern": "^(.*)$"
-              }
-            }
+              "$id": "#/properties/data/properties/answers/items",
+              "anyOf": [
+                  {
+                      "$id": "#/properties/data/properties/answers/items/anyOf/0",
+                      "type": "object",
+                      "title": "General Answer Type",
+                      "required": [
+                        "answer_id",
+                        "value"
+                      ],
+                      "properties": {
+                        "answer_id": {
+                          "$id": "#/properties/data/properties/answers/items/properties/answer_id",
+                          "type": "string",
+                          "title": "Answer ID",
+                          "default": "",
+                          "examples": [
+                            "accommodation-type-answer",
+                            "first-name",
+                            "ethnic-group-answer"
+                          ],
+                          "pattern": "^(.*)$"
+                        },
+                        "value": {
+                          "$id": "#/properties/data/properties/answers/items/properties/value",
+                          "title": "The response value",
+                          "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
+                          "default": "",
+                          "items": {
+                            "$id": "#/properties/data/properties/answers/items/properties/value/items",
+                            "type": "string",
+                            "examples": [
+                              "Christian",
+                              "Buddhist",
+                              "Yes",
+                              "No"
+                            ]
+                          },
+                          "pattern": "^(.*)$"
+                        },
+                        "list_item_id": {
+                          "$id": "#/properties/data/properties/answers/items/properties/list_item_id",
+                          "type": "string",
+                          "title": "List Item ID",
+                          "description": "Related item will have the same ID e.g. first name and last name for the same person",
+                          "default": "",
+                          "examples": [
+                            "zGBdpb"
+                          ],
+                          "pattern": "^(.*)$"
+                        }
+                      }
+
+                  },
+                  {
+                      "$id": "#/properties/data/properties/answers/items/anyOf/1",
+                      "type": "object",
+                      "title": "Address Answer Type",
+                      "examples": [
+                          {
+                              "answer_id": "address-answer",
+                              "value": {
+                                  "line1": "Address Line 1",
+                                  "town": "Town",
+                                  "postcode": "WA10 1AB",
+                                  "uprn": "1"
+                              },
+                              "list_item_id": "abcde"
+                          }
+                      ],
+                      "required": [
+                          "answer_id",
+                          "value"
+                      ],
+                      "properties": {
+                          "answer_id": {
+                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/answer_id",
+                              "type": "string",
+                              "title": "Answer ID",
+                              "default": "",
+                              "examples": [
+                                  "address-answer"
+                              ],
+                              "pattern": "^(.*)$"
+                          },
+                          "value": {
+                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value",
+                              "type": "object",
+                              "title": "Address Answer Value",
+                              "default": {},
+                              "examples": [
+                                  {
+                                      "line1": "Address Line 1",
+                                      "town": "Town",
+                                      "postcode": "NP10 8XG",
+                                      "uprn": "12345678912"
+                                  }
+                              ],
+                              "required": [
+                                  "line1",
+                                  "town",
+                                  "postcode"
+                              ],
+                              "properties": {
+                                  "line1": {
+                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/line1",
+                                      "type": "string",
+                                      "title": "Address line 1",
+                                      "default": "",
+                                      "examples": [
+                                          "1 Example Street"
+                                      ],
+                                      "pattern": "^(.*)$"
+                                  },
+                                  "town": {
+                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/town",
+                                      "type": "string",
+                                      "title": "Town",
+                                      "default": "",
+                                      "examples": [
+                                          "London"
+                                      ],
+                                      "pattern": "^(.*)$"
+                                  },
+                                  "postcode": {
+                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/postcode",
+                                      "type": "string",
+                                      "title": "Post Code",
+                                      "default": "",
+                                      "examples": [
+                                          "WA10 1AB"
+                                      ],
+                                      "pattern": "^(.*)$"
+                                  },
+                                  "uprn": {
+                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/uprn",
+                                      "type": "string",
+                                      "title": "UPRN",
+                                      "default": "",
+                                      "examples": [
+                                          "12345678912"
+                                      ],
+                                      "pattern": "^(.*)$"
+                                  }
+                              },
+                              "additionalProperties": false
+                          },
+                          "list_item_id": {
+                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/list_item_id",
+                              "type": "string",
+                              "title": "The list_item_id schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "cWGwcF"
+                              ],
+                              "pattern": "^(.*)$"
+                          }
+                      },
+                      "additionalProperties": false
+                  },
+                  {
+                      "$id": "#/properties/data/properties/answers/items/anyOf/2",
+                      "type": "object",
+                      "title": "Relationship Answer Type",
+                      "default": {},
+                      "examples": [
+                          {
+                              "answer_id": "relationship-answer",
+                              "value": [
+                                  {
+                                      "list_item_id": "zGBdpb",
+                                      "to_list_item_id": "cWGwcF",
+                                      "relationship": "Husband or Wife"
+                                  }
+                              ]
+                          }
+                      ],
+                      "required": [
+                          "answer_id",
+                          "value"
+                      ],
+                      "properties": {
+                          "answer_id": {
+                              "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/answer_id",
+                              "type": "string",
+                              "title": "Answer ID",
+                              "default": "",
+                              "examples": [
+                                  "relationship-answer"
+                              ],
+                              "pattern": "^(.*)$"
+                          },
+                          "value": {
+                              "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value",
+                              "type": "array",
+                              "uniqueItems": true,
+                              "title": "Relationships Answer Value",
+                              "default": [],
+                              "examples": [
+                                  [
+                                      {
+                                          "list_item_id": "zGBdpb",
+                                          "to_list_item_id": "cWGwcF",
+                                          "relationship": "Husband or Wife"
+                                      }
+                                  ]
+                              ],
+                              "additionalItems": false,
+                              "items": {
+                                  "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items",
+                                  "type": "object",
+                                  "title": "The first anyOf schema",
+                                  "default": {},
+                                  "required": [
+                                      "list_item_id",
+                                      "to_list_item_id",
+                                      "relationship"
+                                  ],
+                                  "properties": {
+                                      "list_item_id": {
+                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/list_item_id",
+                                          "type": "string",
+                                          "title": "List Item ID",
+                                          "default": "",
+                                          "examples": [
+                                              "zGBdpb"
+                                          ],
+                                          "pattern": "^(.*)$"
+                                      },
+                                      "to_list_item_id": {
+                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/to_list_item_id",
+                                          "type": "string",
+                                          "title": "To List Item ID",
+                                          "default": "",
+                                          "examples": [
+                                              "cWGwcF"
+                                          ],
+                                          "pattern": "^(.*)$"
+                                      },
+                                      "relationship": {
+                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/relationship",
+                                          "type": "string",
+                                          "title": "Relationship",
+                                          "default": "",
+                                          "examples": [
+                                              "Husband or Wife"
+                                          ],
+                                          "pattern": "^(.*)$"
+                                      }
+                                  },
+                                  "additionalProperties": false
+                              }
+                          }
+                      },
+                      "additionalProperties": false
+                  }
+              ]
           }
         },
         "lists": {
@@ -397,6 +585,19 @@
                   "zGBdpb"
                 ],
                 "pattern": "^(.*)$"
+              },
+              "same_name_items": {
+                "$id": "#/properties/data/properties/lists/items/anyOf/0/properties/same_name_items",
+                "type": "array",
+                "title": "Same Name Items",
+                "description": "A list of item ids with the same first and last names",
+                "default": [],
+                "examples": [
+                    [
+                      "TLXLDb",
+                      "EINoLs"
+                    ]
+                ]
               }
             }
           }

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -194,6 +194,16 @@
       ],
       "pattern": "^(.*)$"
     },
+    "case_type": {
+      "$id": "#/properties/case_type",
+      "type": "string",
+      "enum": ["HH", "HI", "CE", "CI"],
+      "title": "Case Type",
+      "default": "",
+      "examples": [
+        "HI"
+      ]
+    },
     "launch_language_code": {
       "$id": "#/properties/launch_language_code",
       "type": "string",

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -284,9 +284,9 @@
           "title": "Answer",
           "items": {
               "$id": "#/properties/data/properties/answers/items",
-              "anyOf": [
+              "oneOf": [
                   {
-                      "$id": "#/properties/data/properties/answers/items/anyOf/0",
+                      "$id": "#/properties/data/properties/answers/items/oneOf/0",
                       "type": "object",
                       "title": "General Answer Type",
                       "required": [
@@ -310,6 +310,7 @@
                           "$id": "#/properties/data/properties/answers/items/properties/value",
                           "title": "The response value",
                           "description": "Can be a single string or multiple strings (e.g. for checkboxes)",
+                          "type": ["array", "string", "integer"],
                           "default": "",
                           "items": {
                             "$id": "#/properties/data/properties/answers/items/properties/value/items",
@@ -338,7 +339,7 @@
 
                   },
                   {
-                      "$id": "#/properties/data/properties/answers/items/anyOf/1",
+                      "$id": "#/properties/data/properties/answers/items/oneOf/1",
                       "type": "object",
                       "title": "Address Answer Type",
                       "examples": [
@@ -359,7 +360,7 @@
                       ],
                       "properties": {
                           "answer_id": {
-                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/answer_id",
+                              "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/answer_id",
                               "type": "string",
                               "title": "Answer ID",
                               "default": "",
@@ -369,7 +370,7 @@
                               "pattern": "^(.*)$"
                           },
                           "value": {
-                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value",
+                              "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value",
                               "type": "object",
                               "title": "Address Answer Value",
                               "default": {},
@@ -386,7 +387,7 @@
                               ],
                               "properties": {
                                   "line1": {
-                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/line1",
+                                      "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value/properties/line1",
                                       "type": "string",
                                       "title": "Address line 1",
                                       "default": "",
@@ -396,17 +397,17 @@
                                       "pattern": "^(.*)$"
                                   },
                                   "line2": {
-                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/line2",
+                                      "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value/properties/line2",
                                       "type": "string",
                                       "title": "Address line 2",
                                       "default": "",
                                       "examples": [
-                                          "1 Example Street"
+                                          ""
                                       ],
                                       "pattern": "^(.*)$"
                                   },
                                   "town": {
-                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/town",
+                                      "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value/properties/town",
                                       "type": "string",
                                       "title": "Town",
                                       "default": "",
@@ -416,7 +417,7 @@
                                       "pattern": "^(.*)$"
                                   },
                                   "postcode": {
-                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/postcode",
+                                      "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value/properties/postcode",
                                       "type": "string",
                                       "title": "Post Code",
                                       "default": "",
@@ -426,7 +427,7 @@
                                       "pattern": "^(.*)$"
                                   },
                                   "uprn": {
-                                      "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/value/properties/uprn",
+                                      "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/value/properties/uprn",
                                       "type": "string",
                                       "title": "UPRN",
                                       "default": "",
@@ -439,7 +440,7 @@
                               "additionalProperties": false
                           },
                           "list_item_id": {
-                              "$id": "#/properties/data/properties/answers/items/anyOf/1/properties/list_item_id",
+                              "$id": "#/properties/data/properties/answers/items/oneOf/1/properties/list_item_id",
                               "type": "string",
                               "title": "The list_item_id schema",
                               "description": "An explanation about the purpose of this instance.",
@@ -453,7 +454,7 @@
                       "additionalProperties": false
                   },
                   {
-                      "$id": "#/properties/data/properties/answers/items/anyOf/2",
+                      "$id": "#/properties/data/properties/answers/items/oneOf/2",
                       "type": "object",
                       "title": "Relationship Answer Type",
                       "default": {},
@@ -475,7 +476,7 @@
                       ],
                       "properties": {
                           "answer_id": {
-                              "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/answer_id",
+                              "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/answer_id",
                               "type": "string",
                               "title": "Answer ID",
                               "default": "",
@@ -485,7 +486,7 @@
                               "pattern": "^(.*)$"
                           },
                           "value": {
-                              "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value",
+                              "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/value",
                               "type": "array",
                               "uniqueItems": true,
                               "title": "Relationships Answer Value",
@@ -501,9 +502,9 @@
                               ],
                               "additionalItems": false,
                               "items": {
-                                  "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items",
+                                  "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/value/items",
                                   "type": "object",
-                                  "title": "The first anyOf schema",
+                                  "title": "The first oneOf schema",
                                   "default": {},
                                   "required": [
                                       "list_item_id",
@@ -512,7 +513,7 @@
                                   ],
                                   "properties": {
                                       "list_item_id": {
-                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/list_item_id",
+                                          "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/value/items/properties/list_item_id",
                                           "type": "string",
                                           "title": "List Item ID",
                                           "default": "",
@@ -522,7 +523,7 @@
                                           "pattern": "^(.*)$"
                                       },
                                       "to_list_item_id": {
-                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/to_list_item_id",
+                                          "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/value/items/properties/to_list_item_id",
                                           "type": "string",
                                           "title": "To List Item ID",
                                           "default": "",
@@ -532,7 +533,7 @@
                                           "pattern": "^(.*)$"
                                       },
                                       "relationship": {
-                                          "$id": "#/properties/data/properties/answers/items/anyOf/2/properties/value/items/properties/relationship",
+                                          "$id": "#/properties/data/properties/answers/items/oneOf/2/properties/value/items/properties/relationship",
                                           "type": "string",
                                           "title": "Relationship",
                                           "default": "",
@@ -605,7 +606,7 @@
                 "pattern": "^(.*)$"
               },
               "same_name_items": {
-                "$id": "#/properties/data/properties/lists/items/anyOf/0/properties/same_name_items",
+                "$id": "#/properties/data/properties/lists/items/oneOf/0/properties/same_name_items",
                 "type": "array",
                 "title": "Same Name Items",
                 "description": "A list of item ids with the same first and last names",


### PR DESCRIPTION
## Context

Updates the EQ schema definitions json schema to include the latest data structures.

The `response_id` has been removed as it is no longer part of the submission data. 

The `case_type` field is now optional.

I have added the schema definition for `relationship` answer types:

```
{
   "answer_id": "relationship-answer",
    "value": [
      {
        "list_item_id": "EINoLs",
         "to_list_item_id": "TLXLDb",
         "relationship": "Husband or wife"
       }
    ]
}
```

 and `address` answer types:
```
{
  "answer_id": "address-answer",
   "value": {
       "line1": "Address Line 1",
       "town": "Town",
       "postcode": "NP10 8XG",
     },
 }
```


I have also added the `same_name_items` field to the `Lists` definition.

The `eq_submisson_example` json file has been expanded to include more answer types.

## How to test

Use the `eq_submssion_example` or generate a submission object from one of the Census schemas and validate it against the updated JSON schema using:

`pipenv run python ./schemas/json_validator.py ./schemas/eq_submission_schema.json ./examples/eq_submission_example.json`
