### PR TITLE
Remove feedback type question category in docs

### DIFF
--- a/docs/electronic_questionnaire_to_downstream.rst
+++ b/docs/electronic_questionnaire_to_downstream.rst
@@ -87,7 +87,6 @@ Schema Definition
 
           - ``feedback_text``
           - ``feedback_type``
-          - ``feedback_type_question_category``
           - ``feedback_count``
 
   ``data`` version 0.0.3

--- a/examples/eq_feedback_example_0_0_1.json
+++ b/examples/eq_feedback_example_0_0_1.json
@@ -7,8 +7,7 @@
   "data": {
     "feedback_text": "Page design feedback",
     "feedback_type": "Page design and structure",
-    "feedback_count": "7",
-    "feedback_type_question_category": "Household and accommodation"
+    "feedback_count": "7"
   },
   "metadata": {
     "ref_period_end_date": "2021-03-29",


### PR DESCRIPTION
# Context
<!--- Why is this change required? What problem does it solve? -->
Removes redundant feedback type question category field from definitions after feedback object has been updated in [this PR in runner](https://github.com/ONSdigital/eq-questionnaire-runner/pull/697).

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
[Runner PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/697)
[Trello card](https://trello.com/c/0sx8Vbk1)
