### PR TITLE
Add legacy instrument id to response

### DIFF
--- a/docs/electronic_questionnaire_to_downstream.rst
+++ b/docs/electronic_questionnaire_to_downstream.rst
@@ -35,7 +35,7 @@ Schema Definition
     The unique type identifier of this JSON file.
     Can be "uk.gov.ons.edc.eq:surveyresponse" or "uk.gov.ons.edc.eq:feedback"
   ``version``
-    The version number of the Runner data payload structure (one of ``0.0.1`` | ``0.0.3``)
+    The version number of the questionnaire schemas ``data_version``. This indicates the data payload convertor that was used (one of ``0.0.1`` | ``0.0.3``)
   ``origin``
     The name or identifier of the data capture system. Currently "uk.gov.ons.edc.eq" (historicaly named for Electronic Data Collection)
   ``survey_id``
@@ -52,6 +52,8 @@ Schema Definition
           The Runner schema representing the question set presented to the respondent
         ``period``
           A string representing the business area's time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey.
+        ``instrument_id`` (deprecated)
+          The same value as the top level ``form_type`` property (required by legacy downstream systems)
   ``case_id``
     The case UUID used to identify an instance of a survey response request (generated in RM, may not be included if no case has been linked at launch time)
   ``case_ref``
@@ -127,6 +129,7 @@ Example 0.0.1 surveyresponse JSON payloads
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
             "period": "JAN2019"
+            "instrument_id": "0203"
         },
         "metadata": {
             "user_id": "1234567890",
@@ -165,6 +168,7 @@ Example 0.0.3 surveyresponse JSON payload (inc. data lists and answers)
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
             "period": "JAN2019"
+            "instrument_id": "0203"
         },
         "metadata": {
             "user_id": "1234567890",
@@ -337,6 +341,7 @@ Example 0.0.1 feedback JSON payload
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
             "period": "JAN2019"
+            "instrument_id": "0203"
         },
         "metadata": {
             "user_id": "1234567890",

--- a/docs/electronic_questionnaire_to_downstream.rst
+++ b/docs/electronic_questionnaire_to_downstream.rst
@@ -128,7 +128,7 @@ Example 0.0.1 surveyresponse JSON payloads
         "collection": {
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
-            "period": "JAN2019"
+            "period": "JAN2019",
             "instrument_id": "0203"
         },
         "metadata": {
@@ -167,7 +167,7 @@ Example 0.0.3 surveyresponse JSON payload (inc. data lists and answers)
         "collection": {
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
-            "period": "JAN2019"
+            "period": "JAN2019",
             "instrument_id": "0203"
         },
         "metadata": {
@@ -340,7 +340,7 @@ Example 0.0.1 feedback JSON payload
         "collection": {
             "exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
             "schema_name": "mbs_0203",
-            "period": "JAN2019"
+            "period": "JAN2019",
             "instrument_id": "0203"
         },
         "metadata": {

--- a/examples/eq_feedback_example_0_0_1.json
+++ b/examples/eq_feedback_example_0_0_1.json
@@ -2,7 +2,8 @@
   "collection": {
     "exercise_sid": "eedbdf46-adac-49f7-b4c3-2251807381c3",
     "schema_name": "carbon_0007",
-    "period": "3003"
+    "period": "3003",
+    "instrument_id": "0123"
   },
   "data": {
     "feedback_text": "Page design feedback",

--- a/examples/eq_submission_example.json
+++ b/examples/eq_submission_example.json
@@ -9,7 +9,8 @@
     "collection": {
         "exercise_sid": "ae62cb63-be41-4160-8bff-eb2a3bab5c6e",
         "schema_name": "test_relationships",
-        "period": "201605"
+        "period": "201605",
+        "instrument_id": "0123"
     },
     "metadata": {
         "user_id": "UNKNOWN",

--- a/examples/eq_submission_example_0_0_1.json
+++ b/examples/eq_submission_example_0_0_1.json
@@ -9,7 +9,8 @@
     "collection": {
         "exercise_sid": "ae62cb63-be41-4160-8bff-eb2a3bab5c6e",
         "schema_name": "test_relationships",
-        "period": "201605"
+        "period": "201605",
+        "instrument_id": "0234"
     },
     "metadata": {
         "user_id": "UNKNOWN",

--- a/examples/eq_submission_example_0_0_3.json
+++ b/examples/eq_submission_example_0_0_3.json
@@ -9,7 +9,8 @@
     "collection": {
         "exercise_sid": "ae62cb63-be41-4160-8bff-eb2a3bab5c6e",
         "schema_name": "test_relationships",
-        "period": "201605"
+        "period": "201605",
+        "instrument_id": "0123"
     },
     "metadata": {
         "user_id": "UNKNOWN",

--- a/schemas/eq_submission_schema.json
+++ b/schemas/eq_submission_schema.json
@@ -111,7 +111,8 @@
       "required": [
         "exercise_sid",
         "schema_name",
-        "period"
+        "period",
+        "instrument_id"
       ],
       "properties": {
         "exercise_sid": {
@@ -141,6 +142,16 @@
           "default": "",
           "examples": [
             "201605"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "instrument_id": {
+          "$id": "#/properties/instrument_id",
+          "type": "string",
+          "title": "Instrument ID",
+          "default": "",
+          "examples": [
+            "0001"
           ],
           "pattern": "^(.*)$"
         }


### PR DESCRIPTION
While the key and value for ``form_type`` exists in the v3 Runner submitted payload, SDX requires that value to exist in a key called ``collection.instrument_id`` to be able to process legacy downstream data. This is because SDX needs to handle two sources of EQ response data and we are not currently able to redesign the existing downstream solutions.

This proposal introduces (and immediately deprecates) the ``collection.instrument_id`` key/value in the EQ response payload to align with the existing platform design.