### PR TITLE
Typo in example type

### DIFF
--- a/docs/electronic_questionnaire_to_downstream.rst
+++ b/docs/electronic_questionnaire_to_downstream.rst
@@ -329,7 +329,7 @@ Example 0.0.1 feedback JSON payload
 
    {
         "tx_id": "ea82c224-0f80-41cc-b877-8a7804b56c26",
-        "type": "uk.gov.ons.edc.eq:surveyresponse",
+        "type": "uk.gov.ons.edc.eq:feedback",
         "version": "0.0.1",
         "origin": "uk.gov.ons.edc.eq",
         "survey_id": "009",


### PR DESCRIPTION
Fixing the `type` in the document example. This is correct in the actual example.json [here](https://github.com/ONSdigital/ons-schema-definitions/blob/v3/examples/eq_feedback_example_0_0_1.json#L24)