### PR TITLE
Make "form_type" and "ru_ref" required fields for business metadata

### DIFF
--- a/schemas/common/survey_metadata.json
+++ b/schemas/common/survey_metadata.json
@@ -47,7 +47,7 @@
           "$ref": "definitions.json#/user_id"
         }
       },
-      "required": ["ru_name", "user_id", "period_id"]
+      "required": ["ru_name", "user_id", "period_id", "form_type", "ru_ref"]
     },
     "adhoc_metadata": {
       "description": "The metadata properties that can be for ad-hoc surveys.",


### PR DESCRIPTION
### What is the context of this PR?
The fields "form_type" and "ru_ref" are required by SDX to complete its transformations on Business Surveys. These fields have therefore been set as required to ensure that SDX can process v2 business submissions.
