### PR TITLE
Support for user-defined answer codes in data version 0.0.3

### DIFF
--- a/docs/eq_runner_data_versions.md
+++ b/docs/eq_runner_data_versions.md
@@ -68,6 +68,7 @@ The version of the data is determined by the `data_version` property defined in 
     - `answer_codes`
         - An array of [answer code objects](#answer-code-object) to represent the `answer_id` (optionally the `answer_value`) to user-defined code relationship.
         - Only contains the mapping for responses provided in `data.answers`. It does not contain the mapping for the entire survey. However, mappings for all option values are provided for answers with option values, regardless of whether the response data contains all option values. eQ only filters the answer codes by `answer_id`. In other words, eQ will send answer codes for all answer_ids for which there is a response.
+        - **Note: answer_codes in the payload are temporary and will be removed once the Collection Instrument Registry (CIR) is in place. Systems requiring the answer_codes will be able to fetch the eQ schema from the CIR which contains the full answer codes mapping avoiding the need to couple it in the eQ payload.**
 
   - For the payload `type` of `feedback` these will typically contain survey feedback form properties with corresponding user entered values.
      - `feedback_text`

--- a/docs/eq_runner_data_versions.md
+++ b/docs/eq_runner_data_versions.md
@@ -59,39 +59,56 @@ The version of the data is determined by the `data_version` property defined in 
 `data`
   An object of key-value pairing.
 
-  - For the payload `type` of `surveyresponse` these will typically contain the list items and answers arrays
+  - For the payload `type` of `surveyresponse` these will typically contain the list items, the answers array and an optional answer codes array.
 
-    `lists`
-      An array of list item objects built up during the questionnaire completion
-
-      **List Item Object**
-
-      - `name`: the name of the list (e.g. `people-who-live-here`)
-      - `items`: an array of strings of the item identifiers in the list
-      - `primary_person`: [optional] the item identifier of the primary person in the list
-
-    `answers`
-      An array of answer objects
-
-      **Answer Object**
-
-      - `value`: the value of the answer(s) provided for the answer_id
-      - `answer_id`: the business defined answer identifier
-      - `list_item_id`: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+    - `lists`
+        - An array of [list item objects](#list-item-object) built up during the questionnaire completion [list item object]
+    - `answers`
+        - An array of [answer objects](#answer-object)
+    - `answer_codes`
+        - An array of [answer code objects](#answer-code-object) to represent the `answer_id` (optionally the `answer_value`) to user-defined code relationship.
+        - Only contains the mapping for responses provided in `data.answers`. It does not contain the mapping for the entire survey. However, mappings for all option values are provided for answers with option values, regardless of whether the response data contains all option values. eQ only filters the answer codes by `answer_id`. In other words, eQ will send answer codes for all answer_ids for which there is a response.
 
   - For the payload `type` of `feedback` these will typically contain survey feedback form properties with corresponding user entered values.
      - `feedback_text`
      - `feedback_type`
      - `feedback_count`
 
+#### List Item Object
+
+- `name`: the name of the list (e.g. `people-who-live-here`)
+- `items`: an array of strings of the item identifiers in the list
+- `primary_person`: [optional] the item identifier of the primary person in the list
+
+#### Answer Object
+
+- `answer_id`: the answer identifier
+- `value`: the value of the answer(s) provided for the `answer_id`
+- `list_item_id`: [optional] the ID of the list item the answer was provided for (if answering in the context of a list item)
+
+#### Answer Code Object
+
+- `answer_id`: the answer identifier
+- `code`: the user-defined answer code
+- `answer_value`: [optional] the option value for answers that support options.
+
+**Rules**
+- The `answer_id` for the answer code object will be present in at least one of the answer objects in `data.answers` and vice versa.
+- The value for `code` is globally unique among all answers.
+- The `answer_value` is an optional key that will only exist for answers that support options such as Radio, Dropdown, Relationship and Checkbox.
+    - The key will only exist when there is a user-defined code against each option.
+
 ### Example data version 0.0.3 for surveyresponse JSON payload
 
 ```json
 "data": {
+    "lists": [
+        ...
+    ],
     "answers": [
         ...
     ],
-    "lists": [
+    "answer_codes": [
         ...
     ]
 }
@@ -210,7 +227,7 @@ The version of the data is determined by the `data_version` property defined in 
 ]
 ```
 
-**Answer Array Example (address type)**
+**Answer Array Example (Address type)**
 
 ```json
 "answers": [
@@ -236,6 +253,35 @@ The version of the data is determined by the `data_version` property defined in 
     }
   }
 ]
+```
+
+**Answer Codes Example**
+
+```json
+"answer_codes": [
+    {
+      "answer_id": "textfield-answer",
+      "code": "1"
+    },
+    {
+      "answer_id": "number-answer",
+      "code": "2"
+    },
+    {
+      "answer_id": "radio-dropdown-checkbox-relationship-answer",
+      "code": "3" // This should only exist and be used for dynamic answers or when codes for each option aren't given.
+    },
+    {
+      "answer_id": "radio-dropdown-checkbox-relationship-answer",
+      "answer_value": "RAD1",  // This is the value of the Dropdown/Radio/Checkbox/Relationship, not the label.
+      "code": "3a"
+    },
+    {
+      "answer_id": "radio-dropdown-checkbox-relationship-answer",
+      "answer_value": "RAD2",  // This is the value of the Dropdown/Radio/Checkbox/Relationship, not the label.
+      "code": "3b"
+    }
+  ],
 ```
 
 ### Example data version 0.0.3 feedback JSON payload

--- a/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_3_with_answer_codes.json
+++ b/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_3_with_answer_codes.json
@@ -1,0 +1,164 @@
+{
+  "tx_id": "a8e1d41d-728c-47c4-89b2-2d087e6e01a4",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "0.0.3",
+  "origin": "uk.gov.ons.edc.eq",
+  "survey_id": "0",
+  "flushed": false,
+  "submitted_at": "2019-08-20T11:05:44.541979",
+  "form_type": "0234",
+  "case_type": "B",
+  "case_ref": "1000000000000001",
+  "channel": "EQ",
+  "collection": {
+    "exercise_sid": "ae62cb63-be41-4160-8bff-eb2a3bab5c6e",
+    "schema_name": "test_relationships",
+    "period": "201605",
+    "instrument_id": "0123"
+  },
+  "metadata": {
+    "user_id": "UNKNOWN",
+    "ru_ref": "74117071486i",
+    "display_address": "1 Road, Town City"
+  },
+  "launch_language_code": "en",
+  "submission_language_code": "cy",
+  "region_code": "GB-ENG",
+  "started_at": "2019-08-20T11:05:25.604330",
+  "case_id": "6453e4d3-aac1-424c-be28-23c57aa9e17d",
+  "data": {
+    "answer_codes": [
+      {
+        "answer_id": "first-name",
+        "code": "1"
+      },
+      {
+        "answer_id": "last-name",
+        "code": "2"
+      },
+      {
+        "answer_id": "anyone-else",
+        "code": "3"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "code": "4"
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "code": "5"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Broadband or WiFi",
+        "code": "6a"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "A mobile phone network such as 3G, 4G or 5G",
+        "code": "6b"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Public WiFi hotspot",
+        "code": "6c"
+      },
+      {
+        "answer_id": "business-type-answer",
+        "code": "7"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "code": "8"
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "code": "9"
+      }
+    ],
+    "answers": [
+      {
+        "answer_id": "first-name",
+        "value": "John",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "first-name",
+        "value": "Marie",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "anyone-else",
+        "value": "No"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "value": 4
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "value": "1990-01-01",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "internet-answer",
+        "value": [
+          "Broadband or WiFi",
+          "A mobile phone network such as 3G, 4G or 5G",
+          "Public WiFi hotspot"
+        ]
+      },
+      {
+        "answer_id": "business-type-answer",
+        "value": "Enter Business type here!",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "value": [
+          {
+            "list_item_id": "zGBdpb",
+            "to_list_item_id": "cWGwcF",
+            "relationship": "Husband or Wife"
+          },
+          {
+            "list_item_id": "nEMpwe",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Son or daughter"
+          },
+          {
+            "list_item_id": "ukGiCK",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Mother or father"
+          }
+        ]
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "value": {
+          "line1": "Address Line 1",
+          "town": "Town",
+          "postcode": "NP10 8XG",
+          "uprn": "12345678912"
+        },
+        "list_item_id": "cWGwcF"
+      }
+    ],
+    "lists": [
+      {
+        "items": ["zGBdpb", "cWGwcF"],
+        "name": "people"
+      }
+    ]
+  }
+}

--- a/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_3_with_answer_codes.json
+++ b/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_3_with_answer_codes.json
@@ -1,0 +1,187 @@
+{
+  "tx_id": "ea82c224-0f80-41cc-b877-8a7804b56c26",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "v2",
+  "data_version": "0.0.3",
+  "origin": "uk.gov.ons.edc.eq",
+  "flushed": false,
+  "submitted_at": "2016-05-21T16:37:56.551086",
+  "launch_language_code": "en",
+  "submission_language_code": "en",
+  "collection_exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
+  "schema_name": "mbs_0001",
+  "started_at": "2016-05-21T16:33:30.665144",
+  "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
+  "region_code": "GB-ENG",
+  "channel": "RH",
+  "survey_metadata": {
+    "survey_id": "009",
+    "case_ref": "1000000000000001",
+    "qid": "0130000000000300"
+  },
+  "data": {
+    "answer_codes": [
+      {
+        "answer_id": "first-name",
+        "code": "1"
+      },
+      {
+        "answer_id": "last-name",
+        "code": "2"
+      },
+      {
+        "answer_id": "anyone-else",
+        "code": "3"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "code": "4"
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "code": "5"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Broadband or WiFi",
+        "code": "6a"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "A mobile phone network such as 3G, 4G or 5G",
+        "code": "6b"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Public WiFi hotspot",
+        "code": "6c"
+      },
+      {
+        "answer_id": "business-type-answer",
+        "code": "7"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "code": "8"
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "code": "9"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 1",
+        "code": "10a"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 2",
+        "code": "10b"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 3 (this is sent but doesn't have to exist in data.answers)",
+        "code": "10c"
+      },
+      {
+        "answer_id": "duration-answer",
+        "code": "11"
+      }
+    ],
+    "answers": [
+      {
+        "answer_id": "first-name",
+        "value": "John",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "first-name",
+        "value": "Marie",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "anyone-else",
+        "value": "No"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "value": 4
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "value": "1990-01-01",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "internet-answer",
+        "value": [
+          "Broadband or WiFi",
+          "A mobile phone network such as 3G, 4G or 5G",
+          "Public WiFi hotspot"
+        ]
+      },
+      {
+        "answer_id": "business-type-answer",
+        "value": "Enter Business type here!",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "value": [
+          {
+            "list_item_id": "zGBdpb",
+            "to_list_item_id": "cWGwcF",
+            "relationship": "Husband or Wife"
+          },
+          {
+            "list_item_id": "nEMpwe",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Son or daughter"
+          },
+          {
+            "list_item_id": "ukGiCK",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Mother or father"
+          }
+        ]
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "value": {
+          "line1": "Address Line 1",
+          "town": "Town",
+          "postcode": "NP10 8XG",
+          "uprn": "12345678912"
+        },
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "value": ["Checkbox 1", "Checkbox 2"]
+      },
+      {
+        "answer_id": "duration-answer",
+        "value": {
+          "years": 1,
+          "months": 2
+        }
+      }
+    ],
+    "lists": [
+      {
+        "items": ["zGBdpb", "cWGwcF"],
+        "name": "people"
+      }
+    ]
+  }
+}

--- a/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_answer_codes.json
+++ b/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_answer_codes.json
@@ -1,0 +1,198 @@
+{
+  "tx_id": "ea82c224-0f80-41cc-b877-8a7804b56c26",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "v2",
+  "data_version": "0.0.3",
+  "origin": "uk.gov.ons.edc.eq",
+  "flushed": false,
+  "submitted_at": "2016-05-21T16:37:56.551086",
+  "launch_language_code": "en",
+  "submission_language_code": "en",
+  "collection_exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
+  "schema_name": "mbs_0001",
+  "started_at": "2016-05-21T16:33:30.665144",
+  "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
+  "region_code": "GB-ENG",
+  "channel": "RAS",
+  "survey_metadata": {
+    "survey_id": "009",
+    "case_ref": "1000000000000001",
+    "case_type": "B",
+    "display_address": "ONS, Government Buildings, Cardiff Rd",
+    "employment_date": "2021-03-01",
+    "form_type": "0253",
+    "period_id": "202101",
+    "period_str": "January 2021",
+    "ref_p_end_date": "2021-06-01",
+    "ref_p_start_date": "2021-01-01",
+    "ru_name": "ACME T&T Limited",
+    "ru_ref": "49900000001A",
+    "trad_as": "ACME LTD.",
+    "user_id": "64389274239"
+  },
+  "data": {
+    "answer_codes": [
+      {
+        "answer_id": "first-name",
+        "code": "1"
+      },
+      {
+        "answer_id": "last-name",
+        "code": "2"
+      },
+      {
+        "answer_id": "anyone-else",
+        "code": "3"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "code": "4"
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "code": "5"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Broadband or WiFi",
+        "code": "6a"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "A mobile phone network such as 3G, 4G or 5G",
+        "code": "6b"
+      },
+      {
+        "answer_id": "internet-answer",
+        "answer_value": "Public WiFi hotspot",
+        "code": "6c"
+      },
+      {
+        "answer_id": "business-type-answer",
+        "code": "7"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "code": "8"
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "code": "9"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 1",
+        "code": "10a"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 2",
+        "code": "10b"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "answer_value": "Checkbox 3 (this is sent but doesn't have to exist in data.answers)",
+        "code": "10c"
+      },
+      {
+        "answer_id": "duration-answer",
+        "code": "11"
+      }
+    ],
+    "answers": [
+      {
+        "answer_id": "first-name",
+        "value": "John",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "first-name",
+        "value": "Marie",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "anyone-else",
+        "value": "No"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "value": 4
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "value": "1990-01-01",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "internet-answer",
+        "value": [
+          "Broadband or WiFi",
+          "A mobile phone network such as 3G, 4G or 5G",
+          "Public WiFi hotspot"
+        ]
+      },
+      {
+        "answer_id": "business-type-answer",
+        "value": "Enter Business type here!",
+        "list_item_id": "EINoLs"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "value": [
+          {
+            "list_item_id": "zGBdpb",
+            "to_list_item_id": "cWGwcF",
+            "relationship": "Husband or Wife"
+          },
+          {
+            "list_item_id": "nEMpwe",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Son or daughter"
+          },
+          {
+            "list_item_id": "ukGiCK",
+            "to_list_item_id": "adNCSi",
+            "relationship": "Mother or father"
+          }
+        ]
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "value": {
+          "line1": "Address Line 1",
+          "town": "Town",
+          "postcode": "NP10 8XG",
+          "uprn": "12345678912"
+        },
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "value": ["Checkbox 1", "Checkbox 2"]
+      },
+      {
+        "answer_id": "duration-answer",
+        "value": {
+          "years": 1,
+          "months": 2
+        }
+      }
+    ],
+    "lists": [
+      {
+        "items": ["zGBdpb", "cWGwcF"],
+        "name": "people"
+      }
+    ]
+  }
+}

--- a/schemas/common/response_data.json
+++ b/schemas/common/response_data.json
@@ -153,6 +153,25 @@
         ]
       ]
     },
+    "answer_values": {
+      "oneOf": [
+        {
+          "$ref": "response_data.json#/$defs/generic_answer_value"
+        },
+        {
+          "$ref": "response_data.json#/$defs/checkbox_answer_value"
+        },
+        {
+          "$ref": "response_data.json#/$defs/duration_answer_value"
+        },
+        {
+          "$ref": "response_data.json#/$defs/address_answer_value"
+        },
+        {
+          "$ref": "response_data.json#/$defs/relationship_answer_value"
+        }
+      ]
+    },
     "data_version_0_0_3_lists": {
       "type": "array",
       "description": "An array of list item objects built up during the questionnaire completion.",
@@ -188,6 +207,32 @@
         "unevaluatedProperties": false
       }
     },
+    "data_version_0_0_3_answer_codes": {
+      "type": "array",
+      "description": "An array of answer code objects to represent the `answer_id` (optionally the `answer_value`) to user-defined code relationship",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "description": "An answer code mapping object.",
+        "properties": {
+          "answer_id": {
+            "$ref": "response_data.json#/$defs/answer_id"
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._-]+$",
+            "description": "The user-defined answer code."
+          },
+          "answer_value": {
+            "$ref": "response_data.json#/$defs/answer_values"
+          }
+        },
+        "additionalProperties": false,
+        "unevaluatedProperties": false,
+        "required": ["answer_id", "code"]
+      }
+    },
     "data_version_0_0_3_answers": {
       "type": "array",
       "description": "An array of answers built up during the questionnaire completion.",
@@ -199,23 +244,7 @@
             "$ref": "response_data.json#/$defs/answer_id"
           },
           "value": {
-            "oneOf": [
-              {
-                "$ref": "response_data.json#/$defs/generic_answer_value"
-              },
-              {
-                "$ref": "response_data.json#/$defs/checkbox_answer_value"
-              },
-              {
-                "$ref": "response_data.json#/$defs/duration_answer_value"
-              },
-              {
-                "$ref": "response_data.json#/$defs/address_answer_value"
-              },
-              {
-                "$ref": "response_data.json#/$defs/relationship_answer_value"
-              }
-            ]
+            "$ref": "response_data.json#/$defs/answer_values"
           },
           "list_item_id": {
             "$ref": "response_data.json#/$defs/list_item_id",
@@ -291,6 +320,9 @@
     "type": "object",
     "description": "This is used for data_version 0.0.3 survey submissions.",
     "properties": {
+      "answer_codes": {
+        "$ref": "response_data.json#/$defs/data_version_0_0_3_answer_codes"
+      },
       "answers": {
         "$ref": "response_data.json#/$defs/data_version_0_0_3_answers"
       },


### PR DESCRIPTION
### What is the context of this PR?
Currently, data version 0.0.3 does not allow authors to define `ids`/`codes` for answers. Although `answer_id` is exposed in the downstream payload, it is not a user defined code. Answer IDs are system generated and are subject to change even during a collection exercise.

This PR documents the new changes in data version 0.0.3 that will allow SDX to map answers to user-defined codes.

### Links
- Q codes investigation: https://confluence.ons.gov.uk/display/SDC/Q-Codes+Data+Architecture
- eQ Schema JSON proposal: https://github.com/ONSdigital/eq-questionnaire-validator/blob/proposal-for-user-defined-answer-codes/doc/decisions/0011-user-defined-answer-codes.md

### Checklist

* [x] Changes to the spec have been added to example schemas in [examples/](examples/)
* [x] JSON Schema definitions have been updated
