### PR TITLE
Update regex for q_codes to match answer codes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,12 @@ docs/eq_runner_to_downstream_payload_v2.md @ONSdigital/eq-runner @ONSdigital/sdx
 docs/eq_runner_data_versions.md @ONSdigital/eq-runner @ONSdigital/sdx
 
 docs/survey_data_exchange_to_respondent_account_services.md @ONSdigital/sdx @ONSdigital/sdc-rmras
+
+examples/rm_to_eq_runner/* @ONSdigital/eq-runner @ONSdigital/sdc-rmras @ONSdigital/census-response-management
+examples/eq_runner_to_downstream/* @ONSdigital/eq-runner @ONSdigital/sdx
+
+schemas/launch_v1.json @ONSdigital/eq-runner @ONSdigital/sdc-rmras @ONSdigital/census-response-management
+schemas/launch_v2.json @ONSdigital/eq-runner @ONSdigital/sdc-rmras @ONSdigital/census-response-management
+
+schemas/submission_v1.json @ONSdigital/eq-runner @ONSdigital/sdx
+schemas/submission_v2.json @ONSdigital/eq-runner @ONSdigital/sdx

--- a/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_1.json
+++ b/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_1.json
@@ -32,6 +32,6 @@
     "ABC-123": "This is an answer to q_code ABC-123",
     "0002": "This is an answer to q_code 0002",
     "xyz1": "This is an answer to q_code xyz1",
-    "ABC-123-xyz": "This is an answer to q_code ABC-123-xyz"
+    "ABC_123_xyz": "This is an answer to q_code ABC-123-xyz"
   }
 }

--- a/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_1.json
+++ b/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_1.json
@@ -29,8 +29,9 @@
     "ref_period_end_date": "2019-10-31"
   },
   "data": {
-    "0001": "This is an answer to q_code 0001",
+    "ABC-123": "This is an answer to q_code ABC-123",
     "0002": "This is an answer to q_code 0002",
-    "0003": "This is an answer to q_code 0003"
+    "xyz1": "This is an answer to q_code xyz1",
+    "ABC-123-xyz": "This is an answer to q_code ABC-123-xyz"
   }
 }

--- a/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_1.json
+++ b/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_1.json
@@ -30,6 +30,6 @@
     "ABC-123": "This is an answer to q_code ABC-123",
     "0002": "This is an answer to q_code 0002",
     "xyz1": "This is an answer to q_code xyz1",
-    "ABC-123-xyz": "This is an answer to q_code ABC-123-xyz"
+    "ABC_123_xyz": "This is an answer to q_code ABC-123-xyz"
   }
 }

--- a/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_1.json
+++ b/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_1.json
@@ -27,8 +27,9 @@
     "FIRST_NAME": "Vinny"
   },
   "data": {
-    "0001": "This is an answer to q_code 0001",
+    "ABC-123": "This is an answer to q_code ABC-123",
     "0002": "This is an answer to q_code 0002",
-    "0003": "This is an answer to q_code 0003"
+    "xyz1": "This is an answer to q_code xyz1",
+    "ABC-123-xyz": "This is an answer to q_code ABC-123-xyz"
   }
 }

--- a/schemas/common/response_data.json
+++ b/schemas/common/response_data.json
@@ -308,7 +308,7 @@
     "type": "object",
     "description": "This is used for data_version 0.0.1 survey submissions.",
     "patternProperties": {
-      "^[0-9a-z]+$": {
+      "^[a-zA-Z0-9._-]+$": {
         "$ref": "definitions.json#/non_empty_string",
         "description": "The answer value."
       }


### PR DESCRIPTION
### What is the context of this PR?
Updates the regex for `q_code` to match `answer_codes` which allows for capitals, hypens, underscores etc. some of which are needed for new surveys.

### Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->

### Checklist

* [x] Changes to the spec have been added to example schemas in [examples/](examples/)
* [x] JSON Schema definitions have been updated
