### PR TITLE
Add support for decimals in answer payload

### DIFF
--- a/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_3.json
+++ b/examples/eq_runner_to_downstream/payload_v1/surveyresponse_0_0_3.json
@@ -57,6 +57,10 @@
         "value": 4
       },
       {
+        "answer_id": "number-of-items-answer",
+        "value": 4.5
+      },
+      {
         "answer_id": "date-of-birth-answer",
         "value": "1990-01-01",
         "list_item_id": "EINoLs"

--- a/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_3.json
+++ b/examples/eq_runner_to_downstream/payload_v2/adhoc/surveyresponse_0_0_3.json
@@ -61,6 +61,10 @@
         "value": 4
       },
       {
+        "answer_id": "number-of-items-answer",
+        "value": 4.5
+      },
+      {
         "answer_id": "date-of-birth-answer",
         "value": "1990-01-01",
         "list_item_id": "EINoLs"

--- a/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3.json
+++ b/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3.json
@@ -61,6 +61,10 @@
         "value": 4
       },
       {
+        "answer_id": "number-of-items-answer",
+        "value": 4.5
+      },
+      {
         "answer_id": "date-of-birth-answer",
         "value": "1990-01-01",
         "list_item_id": "EINoLs"

--- a/schemas/common/response_data.json
+++ b/schemas/common/response_data.json
@@ -28,7 +28,7 @@
           "$ref": "definitions.json#/non_empty_string"
         },
         {
-          "type": "integer"
+          "type": "number"
         }
       ],
       "description": "The value a non-composite answer.",


### PR DESCRIPTION
### What is the context of this PR?
Previously we only supported integer and string in our answer payload. Updated so that we also allow decimal values.

### Links
Check the change is correct and that the updated example schemas pass validation.

### Checklist

* [ ] Changes to the spec have been added to example schemas in [examples/](examples/)
* [ ] JSON Schema definitions have been updated
