### PR TITLE
Add support for supplementary data

### DIFF
--- a/docs/eq_runner_data_versions.md
+++ b/docs/eq_runner_data_versions.md
@@ -69,7 +69,9 @@ The version of the data is determined by the `data_version` property defined in 
         - An array of [answer code objects](#answer-code-object) to represent the `answer_id` (optionally the `answer_value`) to user-defined code relationship.
         - Only contains the mapping for responses provided in `data.answers`. It does not contain the mapping for the entire survey. However, mappings for all option values are provided for answers with option values, regardless of whether the response data contains all option values. eQ only filters the answer codes by `answer_id`. In other words, eQ will send answer codes for all answer_ids for which there is a response.
         - **Note: answer_codes in the payload are temporary and will be removed once the Collection Instrument Registry (CIR) is in place. Systems requiring the answer_codes will be able to fetch the eQ schema from the CIR which contains the full answer codes mapping avoiding the need to couple it in the eQ payload.**
-
+    - `supplementary_data`
+        - The contents of a [supplementary data schema][sds_schemas_repo]
+      
   - For the payload `type` of `feedback` these will typically contain survey feedback form properties with corresponding user entered values.
      - `feedback_text`
      - `feedback_type`
@@ -80,6 +82,7 @@ The version of the data is determined by the `data_version` property defined in 
 - `name`: the name of the list (e.g. `people-who-live-here`)
 - `items`: an array of strings of the item identifiers in the list
 - `primary_person`: [optional] the item identifier of the primary person in the list
+- `supplementary_data_mapping`: [optional] a map of supplementary data list item identifiers to their corresponding list item id in runner
 
 #### Answer Object
 
@@ -132,6 +135,31 @@ The version of the data is determined by the `data_version` property defined in 
         "items": [
             "vgeYGW"
         ]
+    }
+]
+```
+
+**Lists Array Example (supplementary data)**
+
+```json
+"lists": [
+    {
+        "name": "products",
+        "items": [
+            "ywFBww",
+            "XtjjTB"
+        ],
+        "supplementary_data_mapping": {
+            "89929001": "ywFBww",
+            "202346331": "XtjjTB"
+        }     
+    },
+    {
+        "items": [
+            "UqlQQY",
+            "zfqCLS"
+        ],
+        "name": "additional-employees"
     }
 ]
 ```
@@ -285,8 +313,47 @@ The version of the data is determined by the `data_version` property defined in 
   ],
 ```
 
+**Supplementary Data Example**
+
+```json
+{
+  "schema_version": "v1",
+  "identifier": "50000035606",
+  "items": {
+    "local_units": [
+      {
+        "identifier": "3340224",
+        "lu_name": "STUBBS BUILDING PRODUCTS LTD",
+        "lu_address": [
+          "WELLINGTON ROAD",
+          "LOCHMABEN",
+          "SWINDON",
+          "BEDS",
+          "GLOS",
+          "DE41 2WA"
+        ]
+      },
+      {
+        "identifier": "20047673",
+        "lu_name": "HOPSCOTCH INDUSTRIES UK LTD",
+        "lu_address": [
+          "SOUTH CERNEY WORKS",
+          "SHAWELL LANE",
+          "BEENHAM",
+          "STAFFS",
+          "BEDFORDSHIRE",
+          "GL4 5YU"
+        ]
+      }
+    ]
+  }
+}
+```
+
 ### Example data version 0.0.3 feedback JSON payload
 
 Feedback data format for `0.0.3` is the same as `0.0.1`. 
  - Format 1: [Example data version 0.0.1 for feedback JSON payload (Format 1)](#example-data-version-001-for-feedback-json-payload-format-1)
  - Format 2: [Example data version 0.0.1 for feedback JSON payload (Format 2)](#example-data-version-001-for-feedback-json-payload-format-2)
+
+[sds_schemas_repo]: https://github.com/ONSdigital/sds-schema-definitions/tree/main/schemas "Supplementary Data Schemas Repo"

--- a/docs/eq_runner_to_downstream_payload_v2.md
+++ b/docs/eq_runner_to_downstream_payload_v2.md
@@ -81,7 +81,8 @@ EQ Runner will pass the following keys if a value for them exists.
 		"ru_name": "ACME T&T Limited",
 		"ru_ref": "49900000001A",
 		"trad_as": "ACME LTD.",
-		"user_id": "64389274239"
+		"user_id": "64389274239",
+		"sds_dataset_id": "c067f6de-6d64-42b1-8b02-431a3486c178"
 	},
 
 	// For data version 0.0.1 surveyresponse or both 0.0.1 and 0.0.3 versions of feedback
@@ -92,7 +93,8 @@ EQ Runner will pass the following keys if a value for them exists.
 	// For data version 0.0.3 surveyresponse
 	"data": {
 		"answers": [...]
-		"lists": [...]
+		"lists": [...],
+		"supplementary_data": {...}
 	}
 }
 ```

--- a/docs/rm_to_eq_runner_payload_v2.md
+++ b/docs/rm_to_eq_runner_payload_v2.md
@@ -74,7 +74,7 @@ The data property must adhere to one of [Business Survey Metadata][business_surv
 ##### Business Survey Metadata
 
 | **Property**         | **Definition**                                                                                                                                                                |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **case_ref**         | The case reference (e.g. "1000000000000001")                                                                                                                                  |
 | **case_type**        | The type of case                                                                                                                                                              |
 | **display_address**  | The case's address to be displayed                                                                                                                                            |
@@ -88,7 +88,8 @@ The data property must adhere to one of [Business Survey Metadata][business_surv
 | **ru_name**          | The reporting unit’s display name                                                                                                                                             |
 | **trad_as**          | The reporting unit's 'trading as' name                                                                                                                                        |
 | **user_id**          | The id assigned by the respondent management system                                                                                                                           |
-| **survey_id**        | The survey identifier as used across the ONS.                                                                                                                                                                              |
+| **survey_id**        | The survey identifier as used across the ONS                                                                                                                                  |
+| **sds_dataset_id**   | The UUID of the dataset eQ runner will use to query SDS                                                                                                                       |
 
 For a list of required fields please view [survey metadata definition schema](../schemas/common/survey_metadata.json#L53).
 An example of a valid schema can be found in examples, payload_v2, [launch_jwt_business](../examples/rm_to_eq_runner/payload_v2/launch_jwt_business.json)

--- a/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_supplementary_data.json
+++ b/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_supplementary_data.json
@@ -1,0 +1,229 @@
+{
+  "case_id": "79941c2c-b74e-476c-a80e-e73d62f91fde",
+  "tx_id": "43c636bb-975b-4b2f-a5b9-6b696c377c61",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "v2",
+  "data_version": "0.0.3",
+  "origin": "uk.gov.ons.edc.eq",
+  "collection_exercise_sid": "41834e4b-ba01-4cb0-9da5-a5da011b8abd",
+  "schema_name": "test_supplementary_data",
+  "flushed": false,
+  "submitted_at": "2023-08-23T08:17:34+00:00",
+  "launch_language_code": "en",
+  "survey_metadata": {
+    "survey_id": "123",
+    "form_type": "0253",
+    "ru_name": "ESSENTIAL ENTERPRISE LTD.",
+    "period_id": "201605",
+    "sds_dataset_id": "c067f6de-6d64-42b1-8b02-431a3486c178",
+    "user_id": "UNKNOWN",
+    "ru_ref": "12346789012A"
+  },
+  "data": {
+    "answers": [
+      {
+        "answer_id": "same-email-answer",
+        "value": "Yes"
+      },
+      {
+        "answer_id": "trading-answer",
+        "value": "1947-11-30"
+      },
+      {
+        "answer_id": "sales-bristol-answer",
+        "value": 12345
+      },
+      {
+        "answer_id": "sales-london-answer",
+        "value": 98765
+      },
+      {
+        "answer_id": "list-collector-employees-answer",
+        "value": "No"
+      },
+      {
+        "answer_id": "any-additional-employee-answer",
+        "value": "Yes"
+      },
+      {
+        "answer_id": "employee-first-name",
+        "value": "John",
+        "list_item_id": "UqlQQY"
+      },
+      {
+        "answer_id": "employee-last-name",
+        "value": "Doe",
+        "list_item_id": "UqlQQY"
+      },
+      {
+        "answer_id": "employee-first-name",
+        "value": "Jane",
+        "list_item_id": "zfqCLS"
+      },
+      {
+        "answer_id": "employee-last-name",
+        "value": "Smith",
+        "list_item_id": "zfqCLS"
+      },
+      {
+        "answer_id": "list-collector-additional-answer",
+        "value": "No"
+      },
+      {
+        "answer_id": "employment-start",
+        "value": "2000-11-30",
+        "list_item_id": "zPDHbT"
+      },
+      {
+        "answer_id": "additional-employment-start",
+        "value": "2000-11-30",
+        "list_item_id": "UqlQQY"
+      },
+      {
+        "answer_id": "additional-employment-start",
+        "value": "2000-11-30",
+        "list_item_id": "zfqCLS"
+      },
+      {
+        "answer_id": "list-collector-products-answer",
+        "value": "No"
+      },
+      {
+        "answer_id": "product-sales-answer",
+        "value": 20,
+        "list_item_id": "ywFBww"
+      },
+      {
+        "answer_id": "product-sales-answer",
+        "value": 30,
+        "list_item_id": "XtjjTB"
+      }
+    ],
+    "lists": [
+      {
+        "items": ["ywFBww", "XtjjTB"],
+        "name": "products",
+        "supplementary_data_mapping": {
+          "89929001": "ywFBww",
+          "202346331": "XtjjTB"
+        }
+      },
+      {
+        "items": ["zPDHbT"],
+        "name": "employees",
+        "supplementary_data_mapping": {
+          "429001": "zPDHbT"
+        }
+      },
+      {
+        "items": ["UqlQQY", "zfqCLS"],
+        "name": "additional-employees"
+      }
+    ],
+    "supplementary_data": {
+      "schema_version": "v1",
+      "items": {
+        "products": [
+          {
+            "identifier": "89929001",
+            "guidance_exclude": {
+              "title": "Exclude",
+              "list": [
+                "sports holdalls, gloves, clothing of textile materials, footwear, protective eyewear, rackets, balls, skates",
+                "for skiing, water sports, golf, fishing', for skiing, water sports, golf, fishing, table tennis, PE, gymnastics, athletics"
+              ]
+            },
+            "total_volume": {
+              "answer_code": "89929005",
+              "label": "Total volume produced",
+              "unit_label": "Tonnes"
+            },
+            "guidance_include": {
+              "title": "Include",
+              "list": [
+                "for children's playgrounds",
+                "swimming pools and paddling pools"
+              ]
+            },
+            "cn_codes": "2504 + 250610 + 2512 + 2519 + 2524",
+            "value_sales": {
+              "answer_code": "89929001",
+              "label": "Value of sales"
+            },
+            "name": "Articles and equipment for sports or outdoor games",
+            "volume_sales": {
+              "answer_code": "89929002",
+              "label": "Volume of sales",
+              "unit_label": "Tonnes"
+            }
+          },
+          {
+            "identifier": "202346331",
+            "total_volume": {
+              "answer_code": "20234633103",
+              "label": "Total volume produced",
+              "unit_label": "Kilogram"
+            },
+            "guidance_include": {
+              "title": "Include",
+              "list": ["pots and pans", "chopping board"]
+            },
+            "cn_codes": "1028 + 5908 + 5910 + 591110 + 591120",
+            "value_sales": {
+              "answer_code": "20234633101",
+              "label": "Value of sales"
+            },
+            "name": "Kitchen Equipment",
+            "volume_sales": {
+              "answer_code": "20234633102",
+              "label": "Volume of sales",
+              "unit_label": "Kilogram"
+            }
+          }
+        ],
+        "employees": [
+          {
+            "identifier": "429001",
+            "personal_details": {
+              "forename": "Henry",
+              "surname": "Green",
+              "address": {
+                "postcode": "BS1 1AJ",
+                "house_number": "12",
+                "city": "Bristol"
+              }
+            },
+            "employment_details": {
+              "job_title": "Customer assistant",
+              "start_date": "2020-01-01",
+              "salary": {
+                "payroll_number": "54345",
+                "value": "25000",
+                "currency": "GBP"
+              }
+            }
+          }
+        ]
+      },
+      "identifier": "12346789012A",
+      "total_uk_sales": 555000.0,
+      "note": {
+        "title": "Value of total sales",
+        "description": "Total value of goods sold during the period of the return",
+        "example": {
+          "title": "Including",
+          "description": "Sales across all UK stores"
+        }
+      },
+      "company_details": {
+        "telephone_number": "01171231231",
+        "email": "contact@tesco.org"
+      },
+      "company_name": "Tesco",
+      "guidance": "Some supplementary guidance about the survey",
+      "incorporation_date": "1947-11-27"
+    }
+  },
+  "started_at": "2023-08-23T08:06:27.801995+00:00",
+  "submission_language_code": "en"
+}

--- a/examples/rm_to_eq_runner/payload_v2/launch_jwt_business.json
+++ b/examples/rm_to_eq_runner/payload_v2/launch_jwt_business.json
@@ -23,7 +23,8 @@
       "trad_as": "TOTAL UK ACTIVITY  ",
       "user_id": "855a454c-c6d8-4fcb-94c6-26a4b9732b42",
       "survey_id": "139",
-      "employment_date": "2023-05-18"
+      "employment_date": "2023-05-18",
+      "sds_dataset_id": "c067f6de-6d64-42b1-8b02-431a3486c178"
     }
   }
 }

--- a/schemas/common/definitions.json
+++ b/schemas/common/definitions.json
@@ -265,5 +265,11 @@
     "$ref": "#/non_empty_string",
     "description": "Respondents first name for display (PHM specific)",
     "examples": ["08 Jan 2023"]
+  },
+  "sds_dataset_id": {
+    "type": "string",
+    "description": "The id of the dataset that eQ will use to query SDS",
+    "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$",
+    "examples": ["1be356de-bde7-48bf-b169-00e0b3822a9c"]
   }
 }

--- a/schemas/common/response_data.json
+++ b/schemas/common/response_data.json
@@ -201,6 +201,16 @@
             "items": {
               "$ref": "response_data.json#/$defs/list_item_id"
             }
+          },
+          "supplementary_data_mapping": {
+            "type": "object",
+            "description": "A map of supplementary data list item identifiers to their corresponding list item ids in runner",
+            "patternProperties": {
+              "^[a-zA-Z0-9._-]+$": {
+                "$ref": "response_data.json#/$defs/list_item_id",
+                "description": "The list item id."
+              }
+            }
           }
         },
         "additionalProperties": false,
@@ -255,6 +265,10 @@
         "unevaluatedProperties": false,
         "required": ["answer_id", "value"]
       }
+    },
+    "supplementary_data": {
+      "type": "object",
+      "description": "the unedited contents of a supplementary data schema"
     }
   },
   "feedback_response": {
@@ -328,6 +342,9 @@
       },
       "lists": {
         "$ref": "response_data.json#/$defs/data_version_0_0_3_lists"
+      },
+      "supplementary_data": {
+        "$ref": "response_data.json#/$defs/supplementary_data"
       }
     },
     "additionalProperties": false,

--- a/schemas/common/survey_metadata.json
+++ b/schemas/common/survey_metadata.json
@@ -48,6 +48,9 @@
         },
         "survey_id": {
           "$ref": "definitions.json#/survey_id"
+        },
+        "sds_dataset_id": {
+          "$ref": "definitions.json#/sds_dataset_id"
         }
       },
       "required": [


### PR DESCRIPTION
### What is the context of this PR?
This PR adds support for surveys with supplementary data. It adds the `sds_dataset_id` to the survey metadata and `supplementary_data` and the lists property `supplementary_data_mapping` to the data being sent downstream

### Links
[Readme for the sds schema definitions](https://github.com/ONSdigital/sds-schema-definitions/blob/main/docs/README.md)
schemas and examples are also available in the linked repo

### Checklist

* [ ] Changes to the spec have been added to example schemas in [examples/](examples/)
* [ ] JSON Schema definitions have been updated
