### PR TITLE
Update models to add support for CIR

### DIFF
--- a/docs/eq_runner_to_downstream_payload_v2.md
+++ b/docs/eq_runner_to_downstream_payload_v2.md
@@ -35,7 +35,7 @@ One of the following will be present:
 
 | **Property**          | **Definition**                                                                   |
 |-----------------------|----------------------------------------------------------------------------------|
-| **schema_url**        | A URL for to the remote survey JSON.                                             |
+| **schema_url**        | The URL to the remote survey JSON.                                             |
 | **schema_name**       | The name of the schema launched. Will be present in [Schemas Repo][schemas_repo] |
 | **cir_instrument_id** | The UUID of the collection instrument launched from the registry                 |
 

--- a/docs/eq_runner_to_downstream_payload_v2.md
+++ b/docs/eq_runner_to_downstream_payload_v2.md
@@ -33,10 +33,11 @@ In additional to the field above, a schema selection field will be provided whic
 
 One of the following will be present:
 
-| **Property**    | **Definition**                                                                   |
-| --------------- | -------------------------------------------------------------------------------- |
-| **schema_url**  | A URL for to the remote survey JSON.                                             |
-| **schema_name** | The name of the schema launched. Will be present in [Schemas Repo][schemas_repo] |
+| **Property**          | **Definition**                                                                   |
+|-----------------------|----------------------------------------------------------------------------------|
+| **schema_url**        | A URL for to the remote survey JSON.                                             |
+| **schema_name**       | The name of the schema launched. Will be present in [Schemas Repo][schemas_repo] |
+| **cir_instrument_id** | The UUID of the collection instrument launched from the registry                 |
 
 ### Optional Fields
 

--- a/docs/eq_runner_to_downstream_payload_v2.md
+++ b/docs/eq_runner_to_downstream_payload_v2.md
@@ -31,7 +31,7 @@ This document defines the downstream payload structure for version v2.
 
 In additional to the field above, a schema selection field will be provided which defines the mechanism that was used by EQ Runner to load the questionnaire schema JSON.
 
-One of the following will be present:
+One of the following must be present:
 
 | **Property**          | **Definition**                                                                   |
 |-----------------------|----------------------------------------------------------------------------------|

--- a/docs/rm_to_eq_runner_payload_v2.md
+++ b/docs/rm_to_eq_runner_payload_v2.md
@@ -36,7 +36,7 @@ The schema used by an EQ Runner can be selected one of three ways.
 |-----------------------|---------------------------------------------------------------------------------------------------------------------|
 | **schema_url**        | A URL for a remote survey JSON. This claim is used to tell EQ Runner to load the schema JSON from a remote location |
 | **schema_name**       | The name of the schema to launch. Must be present in [Schemas Repo][schemas_repo]                                   |
-| **cir_instrument_id** | The UUID of the collection instrument launched from the Collection Instrument Registry                              |
+| **cir_instrument_id** | The UUID of the collection instrument to launch from the Collection Instrument Registry                              |
 
 ### Optional Fields
 

--- a/docs/rm_to_eq_runner_payload_v2.md
+++ b/docs/rm_to_eq_runner_payload_v2.md
@@ -30,12 +30,13 @@ The following metadata properties are always required for the EQ Runner, they do
 
 The schema selection field determine the mechanism used by EQ Runner to load the questionnaire schema JSON.
 
-The schema used by an EQ Runner can be selected one of two ways.
+The schema used by an EQ Runner can be selected one of three ways.
 
-| **Property**    | **Definition**                                                                                                      |
-| --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **schema_url**  | A URL for a remote survey JSON. This claim is used to tell EQ Runner to load the schema JSON from a remote location |
-| **schema_name** | The name of the schema to launch. Must be present in [Schemas Repo][schemas_repo]                                   |
+| **Property**          | **Definition**                                                                                                      |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------|
+| **schema_url**        | A URL for a remote survey JSON. This claim is used to tell EQ Runner to load the schema JSON from a remote location |
+| **schema_name**       | The name of the schema to launch. Must be present in [Schemas Repo][schemas_repo]                                   |
+| **cir_instrument_id** | The UUID of the collection instrument launched from the registry                                                    |
 
 ### Optional Fields
 
@@ -73,23 +74,23 @@ The data property must adhere to one of [Business Survey Metadata][business_surv
 
 ##### Business Survey Metadata
 
-| **Property**         | **Definition**                                                                                                                                                                |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **case_ref**         | The case reference (e.g. "1000000000000001")                                                                                                                                  |
-| **case_type**        | The type of case                                                                                                                                                              |
-| **display_address**  | The case's address to be displayed                                                                                                                                            |
-| **employment_date**  | The employment reference date                                                                                                                                                 |
-| **form_type**        | The particular `form_type` for a responding unit                                                                                                                              |
-| **period_id**        | A string representing the business area recognised time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey |
-| **period_str**       | A display name for the `period_id` referenced above                                                                                                                           |
-| **ref_p_start_date** | The reference period's start date                                                                                                                                             |
-| **ref_p_end_date**   | The reference period's end date                                                                                                                                               |
-| **ru_ref**           | The reporting unit reference                                                                                                                                                  |
-| **ru_name**          | The reporting unit’s display name                                                                                                                                             |
-| **trad_as**          | The reporting unit's 'trading as' name                                                                                                                                        |
-| **user_id**          | The id assigned by the respondent management system                                                                                                                           |
-| **survey_id**        | The survey identifier as used across the ONS                                                                                                                                  |
-| **sds_dataset_id**   | The UUID of the dataset eQ Runner will use to query SDS                                                                                                                       |
+| **Property**          | **Definition**                                                                                                                                                                |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **case_ref**          | The case reference (e.g. "1000000000000001")                                                                                                                                  |
+| **case_type**         | The type of case                                                                                                                                                              |
+| **display_address**   | The case's address to be displayed                                                                                                                                            |
+| **employment_date**   | The employment reference date                                                                                                                                                 |
+| **form_type**         | The particular `form_type` for a responding unit                                                                                                                              |
+| **period_id**         | A string representing the business area recognised time period for the collection exercise (e.g. "2019" or "JAN2019" or "2019Q3". This is not the start/end dates of a survey |
+| **period_str**        | A display name for the `period_id` referenced above                                                                                                                           |
+| **ref_p_start_date**  | The reference period's start date                                                                                                                                             |
+| **ref_p_end_date**    | The reference period's end date                                                                                                                                               |
+| **ru_ref**            | The reporting unit reference                                                                                                                                                  |
+| **ru_name**           | The reporting unit’s display name                                                                                                                                             |
+| **trad_as**           | The reporting unit's 'trading as' name                                                                                                                                        |
+| **user_id**           | The id assigned by the respondent management system                                                                                                                           |
+| **survey_id**         | The survey identifier as used across the ONS                                                                                                                                  |
+| **sds_dataset_id**    | The UUID of the dataset eQ Runner will use to query SDS                                                                                                                       |                                                                                       |
 
 For a list of required fields please view [survey metadata definition schema](../schemas/common/survey_metadata.json#L53).
 An example of a valid schema can be found in examples, payload_v2, [launch_jwt_business](../examples/rm_to_eq_runner/payload_v2/launch_jwt_business.json)

--- a/docs/rm_to_eq_runner_payload_v2.md
+++ b/docs/rm_to_eq_runner_payload_v2.md
@@ -36,7 +36,7 @@ The schema used by an EQ Runner can be selected one of three ways.
 |-----------------------|---------------------------------------------------------------------------------------------------------------------|
 | **schema_url**        | A URL for a remote survey JSON. This claim is used to tell EQ Runner to load the schema JSON from a remote location |
 | **schema_name**       | The name of the schema to launch. Must be present in [Schemas Repo][schemas_repo]                                   |
-| **cir_instrument_id** | The UUID of the collection instrument launched from the registry                                                    |
+| **cir_instrument_id** | The UUID of the collection instrument launched from the Collection Instrument Registry                              |
 
 ### Optional Fields
 

--- a/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_cir.json
+++ b/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_cir.json
@@ -1,0 +1,145 @@
+{
+  "tx_id": "ea82c224-0f80-41cc-b877-8a7804b56c26",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "v2",
+  "data_version": "0.0.3",
+  "origin": "uk.gov.ons.edc.eq",
+  "flushed": false,
+  "submitted_at": "2016-05-21T16:37:56.551086",
+  "launch_language_code": "en",
+  "submission_language_code": "en",
+  "collection_exercise_sid": "9ced8dc9-f2f3-49f3-95af-2f3ca0b74ee3",
+  "cir_instrument_id": "c7b0cfa8-147d-4345-8948-813dcbc1539f",
+  "started_at": "2016-05-21T16:33:30.665144",
+  "case_id": "a386b2de-a615-42c8-a0f4-e274f9eb28ee",
+  "region_code": "GB-ENG",
+  "channel": "RAS",
+  "survey_metadata": {
+    "survey_id": "009",
+    "case_ref": "1000000000000001",
+    "case_type": "B",
+    "display_address": "ONS, Government Buildings, Cardiff Rd",
+    "employment_date": "2021-03-01",
+    "form_type": "0253",
+    "period_id": "202101",
+    "period_str": "January 2021",
+    "ref_p_end_date": "2021-06-01",
+    "ref_p_start_date": "2021-01-01",
+    "ru_name": "ACME T&T Limited",
+    "ru_ref": "49900000001A",
+    "trad_as": "ACME LTD.",
+    "user_id": "64389274239"
+  },
+  "data": {
+    "answers": [
+      {
+        "answer_id": "first-name",
+        "value": "John",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "first-name",
+        "value": "Marie",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "cWGwcF"
+      },
+      {
+        "answer_id": "first-name",
+        "value": "Jane",
+        "list_item_id": "nEMpwe"
+      },
+      {
+        "answer_id": "last-name",
+        "value": "Doe",
+        "list_item_id": "nEMpwe"
+      },
+      {
+        "answer_id": "anyone-else",
+        "value": "No"
+      },
+      {
+        "answer_id": "number-of-bedrooms-answer",
+        "value": 4
+      },
+      {
+        "answer_id": "number-of-items-answer",
+        "value": 4.5
+      },
+      {
+        "answer_id": "date-of-birth-answer",
+        "value": "1990-01-01",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "internet-answer",
+        "value": [
+          "Broadband or WiFi",
+          "A mobile phone network such as 3G, 4G or 5G",
+          "Public WiFi hotspot"
+        ]
+      },
+      {
+        "answer_id": "business-type-answer",
+        "value": "Non-profit organisation",
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "relationship-answer",
+        "value": [
+          {
+            "list_item_id": "zGBdpb",
+            "to_list_item_id": "cWGwcF",
+            "relationship": "Husband or Wife"
+          },
+          {
+            "list_item_id": "zGBdpb",
+            "to_list_item_id": "nEMpwe",
+            "relationship": "Son or daughter"
+          },
+          {
+            "list_item_id": "cWGwcF",
+            "to_list_item_id": "nEMpwe",
+            "relationship": "Son or daughter"
+          }
+        ]
+      },
+      {
+        "answer_id": "other-address-uk-answer",
+        "value": {
+          "line1": "Address Line 1",
+          "town": "Town",
+          "postcode": "NP10 8XG",
+          "uprn": "12345678912"
+        },
+        "list_item_id": "zGBdpb"
+      },
+      {
+        "answer_id": "checkbox-answer",
+        "value": ["Checkbox 1", "Checkbox 2"]
+      },
+      {
+        "answer_id": "duration-answer",
+        "value": {
+          "years": 1,
+          "months": 2
+        }
+      }
+    ],
+    "lists": [
+      {
+        "items": ["zGBdpb", "cWGwcF", "nEMpwe"],
+        "name": "people",
+        "primary_person": "zGBdpb"
+      }
+    ]
+  }
+}

--- a/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_cir.json
+++ b/examples/eq_runner_to_downstream/payload_v2/business/surveyresponse_0_0_3_with_cir.json
@@ -43,26 +43,6 @@
         "list_item_id": "zGBdpb"
       },
       {
-        "answer_id": "first-name",
-        "value": "Marie",
-        "list_item_id": "cWGwcF"
-      },
-      {
-        "answer_id": "last-name",
-        "value": "Doe",
-        "list_item_id": "cWGwcF"
-      },
-      {
-        "answer_id": "first-name",
-        "value": "Jane",
-        "list_item_id": "nEMpwe"
-      },
-      {
-        "answer_id": "last-name",
-        "value": "Doe",
-        "list_item_id": "nEMpwe"
-      },
-      {
         "answer_id": "anyone-else",
         "value": "No"
       },
@@ -93,26 +73,6 @@
         "list_item_id": "zGBdpb"
       },
       {
-        "answer_id": "relationship-answer",
-        "value": [
-          {
-            "list_item_id": "zGBdpb",
-            "to_list_item_id": "cWGwcF",
-            "relationship": "Husband or Wife"
-          },
-          {
-            "list_item_id": "zGBdpb",
-            "to_list_item_id": "nEMpwe",
-            "relationship": "Son or daughter"
-          },
-          {
-            "list_item_id": "cWGwcF",
-            "to_list_item_id": "nEMpwe",
-            "relationship": "Son or daughter"
-          }
-        ]
-      },
-      {
         "answer_id": "other-address-uk-answer",
         "value": {
           "line1": "Address Line 1",
@@ -136,7 +96,7 @@
     ],
     "lists": [
       {
-        "items": ["zGBdpb", "cWGwcF", "nEMpwe"],
+        "items": ["zGBdpb"],
         "name": "people",
         "primary_person": "zGBdpb"
       }

--- a/examples/rm_to_eq_runner/payload_v2/launch_jwt_business_cir.json
+++ b/examples/rm_to_eq_runner/payload_v2/launch_jwt_business_cir.json
@@ -1,0 +1,30 @@
+{
+  "exp": 1684501576,
+  "iat": 1684501276,
+  "jti": "47c97acf-ebc2-46bc-b2d0-75e2fcf3ad33",
+  "tx_id": "c44c7942-9956-421e-80d4-c4fa813e13b4",
+  "version": "v2",
+  "account_service_url": "https://upstream.example.com/surveys/todo",
+  "case_id": "c3756c53-28ee-41a4-a382-2dd4f50edf94",
+  "collection_exercise_sid": "b5458b19-8a4e-43ad-8ead-60e900441615",
+  "response_id": "49900000001Fb5458b19-8a4e-43ad-8ead-60e90044161520001",
+  "response_expires_at": "2023-05-23T07:00:00+01:00",
+  "cir_instrument_id": "7cf6ccfd-74e6-49c4-bb37-53385c98d682",
+  "survey_metadata": {
+    "data": {
+      "case_ref": "1000000000000007",
+      "form_type": "0001",
+      "period_id": "1912",
+      "period_str": "December",
+      "ref_p_end_date": "2023-05-18",
+      "ref_p_start_date": "2023-05-23",
+      "ru_name": " RUNAME1_COMPANY1 RUNNAME2_COMPANY1",
+      "ru_ref": "49900000001F",
+      "trad_as": "TOTAL UK ACTIVITY  ",
+      "user_id": "855a454c-c6d8-4fcb-94c6-26a4b9732b42",
+      "survey_id": "139",
+      "employment_date": "2023-05-18",
+      "sds_dataset_id": "c067f6de-6d64-42b1-8b02-431a3486c178"
+    }
+  }
+}

--- a/schemas/common/definitions.json
+++ b/schemas/common/definitions.json
@@ -63,6 +63,10 @@
     "description": "The channel used to launch the EQ.",
     "examples": ["RAS", "RH"]
   },
+  "cir_instrument_id": {
+    "$ref": "#/$defs/uuid",
+    "description": "The UUID for the matching collection instrument in the Collection Instrument Registry."
+  },
   "collection_exercise_sid": {
     "$ref": "#/$defs/uuid",
     "description": "A reference UUID used to represent the collection exercise inside the ONS."

--- a/schemas/launch_v2.json
+++ b/schemas/launch_v2.json
@@ -13,6 +13,9 @@
     "channel": {
       "$ref": "common/definitions.json#/channel"
     },
+    "cir_instrument_id": {
+      "$ref": "common/definitions.json#/cir_instrument_id"
+    },
     "collection_exercise_sid": {
       "$ref": "common/definitions.json#/collection_exercise_sid"
     },
@@ -74,6 +77,9 @@
     },
     {
       "required": ["schema_url"]
+    },
+    {
+      "required": ["cir_instrument_id"]
     }
   ]
 }

--- a/schemas/submission_v2.json
+++ b/schemas/submission_v2.json
@@ -10,6 +10,9 @@
     "channel": {
       "$ref": "common/definitions.json#/channel"
     },
+    "cir_instrument_id": {
+      "$ref": "common/definitions.json#/cir_instrument_id"
+    },
     "collection_exercise_sid": {
       "$ref": "common/definitions.json#/collection_exercise_sid"
     },
@@ -170,6 +173,9 @@
     },
     {
       "required": ["schema_url"]
+    },
+    {
+      "required": ["cir_instrument_id"]
     }
   ]
 }


### PR DESCRIPTION
### What is the context of this PR?

Updates the models to add support for integration with the Collection Instrument Registry via the new `cir_instrument_id` identifier, which will be present in both the upstream and downstream payloads (v2 only).

### Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->

### Checklist

* [ ] Changes to the spec have been added to example schemas in [examples/](examples/)
* [ ] JSON Schema definitions have been updated
