### PR TITLE
Pin Compromised NPM Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-formats": "^2.1.1",
-        "es-main": "^1.2.0",
-        "glob": "^8.0.3",
-        "yargs": "^17.5.1"
+        "ajv": "8.11.0",
+        "ajv-formats": "2.1.1",
+        "es-main": "1.2.0",
+        "glob": "8.0.3",
+        "yargs": "17.5.1"
       },
       "devDependencies": {
-        "eslint": "^8.21.0",
-        "eslint-config-standard": "^17.0.0",
-        "eslint-plugin-json": "^3.1.0",
-        "prettier": "^2.8.7"
+        "eslint": "8.21.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-plugin-json": "3.1.0",
+        "prettier": "2.8.7"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -690,6 +690,17 @@
         "resolve": "^1.20.0"
       }
     },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
@@ -702,6 +713,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-module-utils/node_modules/find-up": {
@@ -853,6 +875,17 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -878,6 +911,14 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eslint-plugin-json": {
       "version": "3.1.0",
@@ -2699,7 +2740,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "debug": "4.3.4",
+        "debug": "^4.3.2",
         "espree": "^9.3.2",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
@@ -2755,7 +2796,7 @@
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "4.3.4",
+        "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -2867,7 +2908,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "requires": {
-        "color-convert": "2.0.1"
+        "color-convert": "^2.0.1"
       }
     },
     "argparse": {
@@ -2964,8 +3005,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "4.3.0",
-        "supports-color": "7.2.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "cliui": {
@@ -2974,8 +3015,8 @@
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0"
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "color-convert": {
@@ -2983,7 +3024,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.4"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
@@ -3137,9 +3178,9 @@
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
-        "chalk": "4.1.2",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "4.3.4",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
@@ -3168,7 +3209,7 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
-        "strip-ansi": "6.0.1",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
@@ -3227,8 +3268,20 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "debug": "4.3.4",
+        "debug": "^3.2.7",
         "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -3238,10 +3291,20 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "debug": "4.3.4",
+        "debug": "^3.2.7",
         "find-up": "^2.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3331,7 +3394,7 @@
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
-        "debug": "4.3.4",
+        "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-module-utils": "^2.7.3",
@@ -3355,6 +3418,16 @@
             "concat-map": "0.0.1"
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -3374,6 +3447,13 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -4395,7 +4475,7 @@
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "6.0.1"
+        "strip-ansi": "^6.0.1"
       }
     },
     "string.prototype.trimend": {
@@ -4427,7 +4507,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "5.0.1"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -4600,9 +4680,9 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
-        "ansi-styles": "4.3.0",
+        "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
-        "strip-ansi": "6.0.1"
+        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,19 +16,10 @@
         "yargs": "^17.5.1"
       },
       "devDependencies": {
-        "ansi-regex": "5.0.1",
-        "ansi-styles": "4.3.0",
-        "chalk": "4.1.2",
-        "color-convert": "2.0.1",
-        "color-name": "1.1.4",
-        "debug": "4.3.4",
         "eslint": "^8.21.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-json": "^3.1.0",
-        "prettier": "^2.8.7",
-        "strip-ansi": "6.0.1",
-        "supports-color": "7.2.0",
-        "wrap-ansi": "7.0.0"
+        "prettier": "^2.8.7"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -699,16 +690,6 @@
         "resolve": "^1.20.0"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/eslint-module-utils": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
@@ -721,16 +702,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-module-utils/node_modules/find-up": {
@@ -882,16 +853,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -917,13 +878,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/eslint-plugin-json": {
       "version": "3.1.0",
@@ -2745,7 +2699,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "debug": "^4.3.2",
+        "debug": "4.3.4",
         "espree": "^9.3.2",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
@@ -2801,7 +2755,7 @@
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "debug": "4.3.4",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -2913,7 +2867,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "requires": {
-        "color-convert": "^2.0.1"
+        "color-convert": "2.0.1"
       }
     },
     "argparse": {
@@ -3010,8 +2964,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "ansi-styles": "4.3.0",
+        "supports-color": "7.2.0"
       }
     },
     "cliui": {
@@ -3020,8 +2974,8 @@
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0"
       }
     },
     "color-convert": {
@@ -3029,7 +2983,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "~1.1.4"
+        "color-name": "1.1.4"
       }
     },
     "color-name": {
@@ -3183,9 +3137,9 @@
         "@humanwhocodes/config-array": "^0.10.4",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
+        "chalk": "4.1.2",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
+        "debug": "4.3.4",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
@@ -3214,7 +3168,7 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
+        "strip-ansi": "6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
@@ -3273,20 +3227,8 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "debug": "^3.2.7",
+        "debug": "4.3.4",
         "resolve": "^1.20.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "eslint-module-utils": {
@@ -3296,20 +3238,10 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "debug": "^3.2.7",
+        "debug": "4.3.4",
         "find-up": "^2.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3399,7 +3331,7 @@
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "debug": "4.3.4",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-module-utils": "^2.7.3",
@@ -3423,16 +3355,6 @@
             "concat-map": "0.0.1"
           }
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -3452,13 +3374,6 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -4480,7 +4395,7 @@
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "strip-ansi": "6.0.1"
       }
     },
     "string.prototype.trimend": {
@@ -4512,7 +4427,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "5.0.1"
       }
     },
     "strip-bom": {
@@ -4685,9 +4600,9 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
-        "ansi-styles": "^4.0.0",
+        "ansi-styles": "4.3.0",
         "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "6.0.1"
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,19 @@
         "yargs": "^17.5.1"
       },
       "devDependencies": {
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "chalk": "4.1.2",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "debug": "4.3.4",
         "eslint": "^8.21.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-json": "^3.1.0",
-        "prettier": "^2.8.7"
+        "prettier": "^2.8.7",
+        "strip-ansi": "6.0.1",
+        "supports-color": "7.2.0",
+        "wrap-ansi": "7.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -238,6 +247,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -246,6 +256,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -374,6 +385,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -399,6 +411,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -409,7 +422,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -436,6 +450,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2428,6 +2443,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2462,6 +2478,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2649,6 +2666,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,27 +23,16 @@
   },
   "homepage": "https://github.com/ONSdigital/ons-schema-definitions#readme",
   "dependencies": {
-    "ajv": "^8.11.0",
-    "ajv-formats": "^2.1.1",
-    "es-main": "^1.2.0",
-    "glob": "^8.0.3",
-    "yargs": "^17.5.1"
+    "ajv": "8.11.0",
+    "ajv-formats": "2.1.1",
+    "es-main": "1.2.0",
+    "glob": "8.0.3",
+    "yargs": "17.5.1"
   },
   "devDependencies": {
-    "eslint": "^8.21.0",
-    "eslint-config-standard": "^17.0.0",
-    "eslint-plugin-json": "^3.1.0",
-    "prettier": "^2.8.7"
-  },
-  "overrides": {
-    "ansi-regex": "5.0.1",
-    "ansi-styles": "4.3.0",
-    "chalk": "4.1.2",
-    "color-convert": "2.0.1",
-    "color-name": "1.1.4",
-    "debug": "4.3.4",
-    "strip-ansi": "6.0.1",
-    "supports-color": "7.2.0",
-    "wrap-ansi": "7.0.0"
+    "eslint": "8.21.0",
+    "eslint-config-standard": "17.0.0",
+    "eslint-plugin-json": "3.1.0",
+    "prettier": "2.8.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,16 +30,18 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
+    "eslint": "^8.21.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-json": "^3.1.0",
+    "prettier": "^2.8.7"
+  },
+  "overrides": {
     "ansi-regex": "5.0.1",
     "ansi-styles": "4.3.0",
     "chalk": "4.1.2",
     "color-convert": "2.0.1",
     "color-name": "1.1.4",
     "debug": "4.3.4",
-    "eslint": "^8.21.0",
-    "eslint-config-standard": "^17.0.0",
-    "eslint-plugin-json": "^3.1.0",
-    "prettier": "^2.8.7",
     "strip-ansi": "6.0.1",
     "supports-color": "7.2.0",
     "wrap-ansi": "7.0.0"

--- a/package.json
+++ b/package.json
@@ -30,9 +30,18 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
+    "ansi-regex": "5.0.1",
+    "ansi-styles": "4.3.0",
+    "chalk": "4.1.2",
+    "color-convert": "2.0.1",
+    "color-name": "1.1.4",
+    "debug": "4.3.4",
     "eslint": "^8.21.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-json": "^3.1.0",
-    "prettier": "^2.8.7"
+    "prettier": "^2.8.7",
+    "strip-ansi": "6.0.1",
+    "supports-color": "7.2.0",
+    "wrap-ansi": "7.0.0"
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Starting September 8th 13:16 UTC it has been reported that the npm `debug` and `chalk` packages were compromised.
In response, we are pinning all development dependencies to prevent any upgrades that could include compromised versions.
### Links


### Checklist

- Packages install as expected
- All compromised packages have been pinned
- Scripts work as expected